### PR TITLE
Remove storybookSource concept

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -14,7 +14,7 @@ Please take a read through this document to help streamline the process of getti
 
 ## Available Tools
 
-Tooling to assist with development of component libraries within the monorepo. 
+Tooling to assist with development of component libraries within the monorepo.
 
 ### Rush
 
@@ -45,13 +45,13 @@ You can start storybook by running the following commands:
     cd packages/apps/storybook
     rushx start
 
-Note: In order for the storybook documentation to be created automatically out of your code, you will need to add a  "storybookSource" property in your `package.json` and set its value to the path of your package's main barrel file (i.e. `"storybookSource": "['src/index.ts']"`). This is work in progress, but should meet your needs for now.
+Note: In order for the storybook documentation to be created automatically out of your code, you will need to declare the component used in the story within storybook, [this story](packages/apps/storybook/src/examples/SampleModuleComponent.stories.tsx) gives details on the required steps.
 
 ### Storybook addons
 
-If your component uses `accessToken` as a prop, you can wrap your story with the `withAccessTokenOverride` HOC, which will use the token from the toolbar add-on instead of what a user could enter in the "Control" section.  See [this story](packages/apps/storybook/src/examples/Authenticated.stories.tsx) for a usage example.
+If your component uses `accessToken` as a prop, you can wrap your story with the `withAccessTokenOverride` HOC, which will use the token from the toolbar add-on instead of what a user could enter in the "Control" section. See [this story](packages/apps/storybook/src/examples/Authenticated.stories.tsx) for a usage example.
 
-Similarly, if your component uses `projectId` as a prop, you can wrap your story with the `withProjectIdOverride` HOC, which will take the projectId from the toolbar add-on. This add-on will only show if the active story has a `projectId` prop and the user is authenticated. The projects that will be available in the toolbar are the authenticated user's **Favorite** Projects in [CONNECT QA](https://qa-connect-webportal.bentley.com/SelectProject/Index#FAVS). To fill the list, you would need to go to CONNECT and toggle favorite for some projects. Note that if you enter a value for `projectId` in the storybook Control panel, the add-on will not override this value. See [this story](packages/apps/storybook/src/examples/ProjectAwareComponent.stories.tsx) for a usage example. 
+Similarly, if your component uses `projectId` as a prop, you can wrap your story with the `withProjectIdOverride` HOC, which will take the projectId from the toolbar add-on. This add-on will only show if the active story has a `projectId` prop and the user is authenticated. The projects that will be available in the toolbar are the authenticated user's **Favorite** Projects in [CONNECT QA](https://qa-connect-webportal.bentley.com/SelectProject/Index#FAVS). To fill the list, you would need to go to CONNECT and toggle favorite for some projects. Note that if you enter a value for `projectId` in the storybook Control panel, the add-on will not override this value. See [this story](packages/apps/storybook/src/examples/ProjectAwareComponent.stories.tsx) for a usage example.
 
 ## Adding a New Project
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -30,7 +30,6 @@ dependencies:
   '@typescript-eslint/parser': 3.10.1_eslint@7.20.0+typescript@4.2.3
   babel-loader: 8.2.2_@babel+core@7.13.1
   classnames: 2.2.6
-  css-loader: 5.2.0
   eslint: 7.20.0
   eslint-config-airbnb: 0.0.4
   eslint-config-prettier: 6.15.0_eslint@7.20.0
@@ -59,9 +58,7 @@ dependencies:
   rollup-plugin-peer-deps-external: 2.2.4_rollup@2.42.4
   rollup-plugin-postcss: 4.0.0_postcss@8.2.8
   rollup-plugin-typescript2: 0.30.0_rollup@2.42.4+typescript@4.2.3
-  sass-loader: 10.1.1_node-sass@5.0.0
   storybook-dark-mode: 1.0.6_16bfb8b22ea2d0be1b21ffb3c73b4fbe
-  style-loader: 2.0.0
   stylelint: 13.11.0
   stylelint-config-prettier: 8.0.2_stylelint@13.11.0
   stylelint-config-sass-guidelines: 7.1.0_stylelint@13.11.0
@@ -20626,7 +20623,7 @@ packages:
       react-dom: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-NkwhfKhtFZdoYoVECNdExGtzUUL78q5Jcxl4guqnda+2y1n3+qx8vlTEvi5alUrVpTT5Nja1BgHivHkDw977qQ==
+      integrity: sha512-F1OrHEGKzYZKwqG6/VHQ/nQUSQoOwOQqrFi3HoC8AmaK1if1pPBXG+hVjBsEy5VgFGfCpj4VGUO4pN072ycIUw==
       tarball: file:projects/platform-storybook.tgz
     version: 0.0.0
   file:projects/storybook-auth-addon.tgz_f7805e32c1d7793bc2164f8c531a8739:
@@ -20690,7 +20687,6 @@ specifiers:
   '@typescript-eslint/parser': ^3.6.0
   babel-loader: ^8.2.2
   classnames: ^2.2.6
-  css-loader: ^5.0.1
   eslint: ^7.4.0
   eslint-config-airbnb: ^0.0.4
   eslint-config-prettier: ^6.11.0
@@ -20719,9 +20715,7 @@ specifiers:
   rollup-plugin-peer-deps-external: ^2.2.4
   rollup-plugin-postcss: ^4.0.0
   rollup-plugin-typescript2: ^0.30.0
-  sass-loader: ^10.1.1
   storybook-dark-mode: ^1.0.4
-  style-loader: ^2.0.0
   stylelint: ^13.6.1
   stylelint-config-prettier: ^8.0.2
   stylelint-config-sass-guidelines: ^7.0.0

--- a/packages/apps/storybook/.storybook/main.js
+++ b/packages/apps/storybook/.storybook/main.js
@@ -14,13 +14,7 @@ module.exports = {
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.
 
-    // Make whatever fine-grained changes you need
-    config.module.rules.push({
-      test: /\.scss$/,
-      use: ["style-loader", "css-loader", "sass-loader"],
-    });
-
-    config.resolve.mainFields = ["storybookSource", "module", "main"];
+    config.resolve.mainFields = ["module", "main"];
 
     // Return the altered config
     return config;

--- a/packages/apps/storybook/package.json
+++ b/packages/apps/storybook/package.json
@@ -17,12 +17,8 @@
     "@storybook/react": "^6.1.11",
     "@storybook/theming": "^6.1.11",
     "babel-loader": "^8.2.2",
-    "css-loader": "^5.0.1",
-    "node-sass": "^5.0.0",
     "rimraf": "^3.0.2",
-    "sass-loader": "^10.1.1",
-    "storybook-dark-mode": "^1.0.4",
-    "style-loader": "^2.0.0"
+    "storybook-dark-mode": "^1.0.4"
   },
   "scripts": {
     "start": "start-storybook -s ./node_modules/@itwin/storybook-auth-addon/build -p 6006",

--- a/packages/apps/storybook/src/examples/SampleModuleComponent.stories.tsx
+++ b/packages/apps/storybook/src/examples/SampleModuleComponent.stories.tsx
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import {
+  IModelThumbnail as ExternalComponent,
+  IModelThumbnailProps,
+} from "@itwin/imodel-browser";
+import { Meta, Story } from "@storybook/react/types-6-0";
+import React from "react";
+
+/**
+ * When using external components in storybook, the documentation will not be built automatically
+ * by the react-docgen-typescript-plugin for these component.
+ * A workaround for this is to declare the components locally so the docgen works.
+ * The numbered steps below describe this process.
+ */
+
+// 1. Imports the external component under a different name from the module
+// Eg: `import { NoResults as ExternalComponent, NoResultsProps } from "@itwin/imodel-browser";`
+
+// 2. Export a newly created component with the original name and imported props type.
+// This component must be exported so react-docgen-typescript can process it.
+// Note that while the props will be properly documented, the component description is not extracted.
+/** Story that demonstrate how to create a story for a component exported from a packages/modules/\*\* package. */
+export const IModelThumbnail = (props: IModelThumbnailProps) => (
+  <ExternalComponent {...props} />
+);
+
+export default {
+  title: "Example/Modules component",
+  // 3. Use the created component in the stories
+  component: IModelThumbnail,
+  // 4. Because we export the component in this file, we need to exclude it as a "Story"
+  excludeStories: ["IModelThumbnail"],
+} as Meta;
+
+// 5. Use the created component in the story template, the props documentation will appear "normal"
+const Template: Story<IModelThumbnailProps> = (args) => (
+  <IModelThumbnail {...args} />
+);
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -3,7 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { IModelGrid, IModelGridProps } from "@itwin/imodel-browser";
+import {
+  IModelGrid as ExternalComponent,
+  IModelGridProps,
+} from "@itwin/imodel-browser";
 import { Meta, Story } from "@storybook/react/types-6-0";
 import React from "react";
 
@@ -13,10 +16,15 @@ import {
   withProjectIdOverride,
 } from "../utils/storyHelp";
 
+export const IModelGrid = (props: IModelGridProps) => (
+  <ExternalComponent {...props} />
+);
+
 export default {
   title: "imodel-browser/IModelGrid",
   component: IModelGrid,
   argTypes: accessTokenArgTypes,
+  excludeStories: ["IModelGrid"],
 } as Meta;
 
 const Template: Story<IModelGridProps> = withProjectIdOverride(

--- a/packages/modules/imodel-browser/package.json
+++ b/packages/modules/imodel-browser/package.json
@@ -15,7 +15,6 @@
     "test": "jest --silent",
     "clean": "rimraf cjs esm"
   },
-  "storybookSource": "src/index.ts",
   "files": [
     "cjs/**/*",
     "esm/**/*"


### PR DESCRIPTION
Removing the need for the "storybookSource" field in package.json to use a different solution.

See [this for some info](packages/apps/storybook/src/examples/SampleModuleComponent.stories.tsx)

