### PR TITLE
iModel browser + create imodel / iModels API changes

### DIFF
--- a/common/changes/@itwin/create-imodel-react/raplemie-iModelAPIChanges_2021-08-03-17-55.json
+++ b/common/changes/@itwin/create-imodel-react/raplemie-iModelAPIChanges_2021-08-03-17-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/create-imodel-react",
+      "comment": "Update iModels API: property `state` instead of `initialized`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/create-imodel-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/imodel-browser-react/raplemie-iModelAPIChanges_2021-08-03-17-55.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-iModelAPIChanges_2021-08-03-17-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Update iModels API: property `state` instead of `initialized`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/imodel-browser-react/raplemie-iModelAPIChanges_2021-08-03-18-01.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-iModelAPIChanges_2021-08-03-18-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Disable imodel thumbnail caching and leave it to the network",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/imodel-browser-react/raplemie-iModelAPIChanges_2021-08-03-18-04.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-iModelAPIChanges_2021-08-03-18-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Support new `search=` project request type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/modules/create-imodel/src/types.ts
+++ b/packages/modules/create-imodel/src/types.ts
@@ -15,8 +15,8 @@ export interface IModelFull {
   /** "Description of the iModel." */
   description?: string | null;
 
-  /** "Boolean flag indicating when iModel is ready to be used." */
-  initialized?: boolean;
+  /** "Enum indicating when iModel is ready to be used." */
+  state?: "initialized" | "notInitialized";
 
   /** "Date when the iModel was created." */
   createdDateTime?: string;

--- a/packages/modules/imodel-browser/src/containers/ProjectGrid/ProjectGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ProjectGrid/ProjectGrid.tsx
@@ -30,8 +30,8 @@ export interface ProjectGridProps {
   /**
    * Access token that requires the `projects:read` scope. */
   accessToken?: string | undefined;
-  /** Type of project to request */
-  requestType?: "favorites" | "recents" | "";
+  /** Type of project to request, "favorite", "recents", "" (empty) or a string starting with "search=" and then the string that will be used to search through project names and numbers */
+  requestType?: "favorites" | "recents" | "" | string; // `search=${string}`
   /** Thumbnail click handler. */
   onThumbnailClick?(project: ProjectFull): void;
   /** String/function that configure Project filtering behavior.
@@ -64,6 +64,8 @@ export interface ProjectGridProps {
     noProjects?: string;
     /** Displayed when the component is mounted but the accessToken is empty. */
     noAuthentication?: string;
+    /** Displayed when the requestType cannot be validated */
+    invalidRequestType?: string;
     /** Generic message displayed if an error occurs while fetching. */
     error?: string;
   };
@@ -94,9 +96,10 @@ export const ProjectGrid = ({
     {
       trialBadge: "Trial",
       inactiveBadge: "Inactive",
-      noIModels: "There are no iModels in this project.",
+      noProjects: "No projects found.",
       noAuthentication: "No access token provided",
       error: "An error occured",
+      invalidRequestType: "Invalid request type",
     },
     stringsOverrides
   );
@@ -110,10 +113,10 @@ export const ProjectGrid = ({
 
   const noResultsText = {
     [DataStatus.Fetching]: "",
-    [DataStatus.Complete]: strings.noIModels,
+    [DataStatus.Complete]: strings.noProjects,
     [DataStatus.FetchFailed]: strings.error,
     [DataStatus.TokenRequired]: strings.noAuthentication,
-    [DataStatus.ContextRequired]: "",
+    [DataStatus.ContextRequired]: strings.invalidRequestType,
   }[fetchStatus ?? DataStatus.Fetching];
 
   React.useEffect(() => {

--- a/packages/modules/imodel-browser/src/containers/ProjectGrid/useProjectData.test.ts
+++ b/packages/modules/imodel-browser/src/containers/ProjectGrid/useProjectData.test.ts
@@ -30,6 +30,22 @@ describe("useProjectData hook", () => {
     });
     expect(result.current.status).toEqual(DataStatus.Complete);
   });
+  it("returns searched projects and proper status on successful call", async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useProjectData({
+        accessToken: "accessToken",
+        requestType: "search=searched",
+      })
+    );
+
+    await waitForNextUpdate();
+    expect(result.current.projects).toContainEqual({
+      id: "my1",
+      displayName: "mySearchediModel",
+    });
+    expect(result.current.status).toEqual(DataStatus.Complete);
+  });
+
   it("returns favorite projects and proper status on successful call", async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useProjectData({ accessToken: "accessToken", requestType: "favorites" })
@@ -202,5 +218,17 @@ describe("useProjectData hook", () => {
     expect(result.current.projects.map((project) => project.id)).toEqual(
       expected
     );
+  });
+
+  it("returns proper status if unknown requestType is provided", async () => {
+    const { result } = renderHook(() =>
+      useProjectData({
+        accessToken: "accessToken",
+        requestType: "searched" as any,
+      })
+    );
+
+    expect(result.current.projects).toEqual([]);
+    expect(result.current.status).toEqual(DataStatus.ContextRequired);
   });
 });

--- a/packages/modules/imodel-browser/src/containers/ProjectGrid/useProjectData.ts
+++ b/packages/modules/imodel-browser/src/containers/ProjectGrid/useProjectData.ts
@@ -16,7 +16,7 @@ import { useProjectFilter } from "./useProjectFilter";
 import { useProjectSort } from "./useProjectSort";
 
 export interface ProjectDataHookOptions {
-  requestType?: "favorites" | "recents" | "";
+  requestType?: "favorites" | "recents" | "" | string; //`search=${string}` |
   accessToken?: string | undefined;
   apiOverrides?: ApiOverrides<ProjectFull[]>;
   filterOptions?: ProjectFilterOptions;
@@ -46,9 +46,20 @@ export const useProjectData = ({
       setProjects([]);
       return;
     }
+    if (
+      !!requestType &&
+      !["favorites", "recents"].includes(requestType) &&
+      !requestType.startsWith("search=")
+    ) {
+      setStatus(DataStatus.ContextRequired);
+      setProjects([]);
+      return;
+    }
     setStatus(DataStatus.Fetching);
     const abortController = new AbortController();
-    const url = `${_getAPIServer(apiOverrides)}/projects/${requestType}`; //[&$skip][&$top]
+    const url = `${_getAPIServer(apiOverrides)}/projects/${
+      (requestType.startsWith("search") ? "?$" : "") + requestType
+    }`; //[&$skip][&$top]
     const options: RequestInit = {
       signal: abortController.signal,
       headers: {

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.test.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.test.ts
@@ -7,7 +7,7 @@ import { rest } from "msw";
 
 import { server } from "../../tests/mocks/server";
 import { DataStatus, IModelSortOptionsKeys } from "../../types";
-import { useIModelData } from "./useIModelData";
+import { IModelDataHookOptions, useIModelData } from "./useIModelData";
 
 describe("useIModelData hook", () => {
   // Establish API mocking before all tests.
@@ -112,7 +112,7 @@ describe("useIModelData hook", () => {
 
   it("apply sorting", async () => {
     const expectedSortOrder = ["2", "4", "5", "1", "3"];
-    const options = {
+    const options: IModelDataHookOptions = {
       apiOverrides: {
         data: [
           {
@@ -120,7 +120,7 @@ describe("useIModelData hook", () => {
             displayName: "d",
             name: "c",
             description: "e",
-            initialized: true,
+            state: "initialized",
             createdDateTime: "2020-09-05T12:42:51.593Z",
           },
           {
@@ -128,7 +128,7 @@ describe("useIModelData hook", () => {
             displayName: "a",
             name: "d",
             description: "d",
-            initialized: true,
+            state: "initialized",
             createdDateTime: "2020-09-03T12:42:51.593Z",
           },
           {
@@ -136,7 +136,7 @@ describe("useIModelData hook", () => {
             displayName: "e",
             name: "a",
             description: "c",
-            initialized: false,
+            state: "notInitialized",
             createdDateTime: "2020-09-04T12:42:51.593Z",
           },
           {
@@ -144,7 +144,7 @@ describe("useIModelData hook", () => {
             displayName: "b",
             name: "b",
             description: "b",
-            initialized: false,
+            state: "notInitialized",
             createdDateTime: "2020-09-01T12:42:51.593Z",
           },
           {
@@ -152,7 +152,7 @@ describe("useIModelData hook", () => {
             displayName: "c",
             name: "d",
             description: "a",
-            initialized: true,
+            state: "initialized",
             createdDateTime: "2020-09-02T12:42:51.593Z",
           },
         ],
@@ -171,7 +171,7 @@ describe("useIModelData hook", () => {
 
   it("apply filtering", async () => {
     const expected = ["2", "5"];
-    const options = {
+    const options: IModelDataHookOptions = {
       apiOverrides: {
         data: [
           {
@@ -179,7 +179,7 @@ describe("useIModelData hook", () => {
             displayName: "d",
             name: "c",
             description: "e",
-            initialized: true,
+            state: "initialized",
             createdDateTime: "2020-09-05T12:42:51.593Z",
           },
           {
@@ -187,7 +187,7 @@ describe("useIModelData hook", () => {
             displayName: "a",
             name: "d",
             description: "d",
-            initialized: true,
+            state: "initialized",
             createdDateTime: "2020-09-03T12:42:51.593Z",
           },
           {
@@ -195,7 +195,7 @@ describe("useIModelData hook", () => {
             displayName: "e",
             name: "a",
             description: "c",
-            initialized: false,
+            state: "notInitialized",
             createdDateTime: "2020-09-04T12:42:51.593Z",
           },
           {
@@ -203,7 +203,7 @@ describe("useIModelData hook", () => {
             displayName: "b",
             name: "b",
             description: "b",
-            initialized: false,
+            state: "notInitialized",
             createdDateTime: "2020-09-01T12:42:51.593Z",
           },
           {
@@ -211,7 +211,7 @@ describe("useIModelData hook", () => {
             displayName: "c",
             name: "d",
             description: "a",
-            initialized: true,
+            state: "initialized",
             createdDateTime: "2020-09-02T12:42:51.593Z",
           },
         ],

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelFilter.test.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelFilter.test.ts
@@ -47,31 +47,31 @@ describe("useIModelFilter hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     // Show only uninitialized.
-    const filterFn = (a: IModelFull) => !a.initialized;
+    const filterFn = (a: IModelFull) => a.state === "notInitialized";
     const { result } = renderHook(() => useIModelFilter(iModels, filterFn));
     expect(result.current.map((iModel) => iModel.id)).toEqual(expected);
   });
@@ -82,31 +82,31 @@ describe("useIModelFilter hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     // Show only uninitialized
-    const filterFn = (a: IModelFull) => !a.initialized;
+    const filterFn = (a: IModelFull) => a.state === "notInitialized";
     const { result } = renderHook(() => useIModelFilter(iModels, filterFn));
 
     expect(result.current).not.toBe(iModels);
@@ -118,27 +118,27 @@ describe("useIModelFilter hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     const { result } = renderHook(() => useIModelFilter(iModels, undefined));

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelSort.test.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelSort.test.ts
@@ -16,14 +16,14 @@ describe("useIModelSort hook", () => {
     "displayName",
     "name",
     "description",
-    "initialized",
+    "state",
     "createdDateTime",
   ] as IModelSortOptionsKeys[])("sorts correctly with %s", (sortType) => {
     const expectedSortOrder = {
       displayName: ["2", "4", "5", "1", "3"],
       name: ["3", "4", "1", "2", "5"],
       description: ["5", "4", "3", "2", "1"],
-      initialized: ["1", "2", "5", "3", "4"],
+      state: ["1", "2", "5", "3", "4"],
       createdDateTime: ["4", "5", "2", "3", "1"],
     }[sortType];
     const iModels: IModelFull[] = [
@@ -32,7 +32,7 @@ describe("useIModelSort hook", () => {
         displayName: "d",
         name: "c",
         description: "e",
-        initialized: true,
+        state: "initialized",
         createdDateTime: "2020-09-05T12:42:51.593Z",
       },
       {
@@ -40,7 +40,7 @@ describe("useIModelSort hook", () => {
         displayName: "a",
         name: "d",
         description: "d",
-        initialized: true,
+        state: "initialized",
         createdDateTime: "2020-09-03T12:42:51.593Z",
       },
       {
@@ -48,7 +48,7 @@ describe("useIModelSort hook", () => {
         displayName: "e",
         name: "a",
         description: "c",
-        initialized: false,
+        state: "notInitialized",
         createdDateTime: "2020-09-04T12:42:51.593Z",
       },
       {
@@ -56,7 +56,7 @@ describe("useIModelSort hook", () => {
         displayName: "b",
         name: "b",
         description: "b",
-        initialized: false,
+        state: "notInitialized",
         createdDateTime: "2020-09-01T12:42:51.593Z",
       },
       {
@@ -64,7 +64,7 @@ describe("useIModelSort hook", () => {
         displayName: "c",
         name: "d",
         description: "a",
-        initialized: true,
+        state: "initialized",
         createdDateTime: "2020-09-02T12:42:51.593Z",
       },
     ];
@@ -89,35 +89,35 @@ describe("useIModelSort hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     // uninitialized first, then sort by display name.
     const sortFn: IModelSortOptions = (a, b) => {
-      if (a.initialized === b.initialized) {
+      if (a.state === b.state) {
         return a.displayName?.localeCompare(b.displayName as string) ?? 0;
       }
-      return a.initialized ? 1 : -1;
+      return b.state?.localeCompare(a.state as string) ?? 0;
     };
     const { result } = renderHook(() => useIModelSort(iModels, sortFn));
     expect(result.current.map((iModel) => iModel.id)).toEqual(
@@ -131,35 +131,35 @@ describe("useIModelSort hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     // uninitialized first, then sort by display name.
     const sortFn: IModelSortOptions = (a, b) => {
-      if (a.initialized === b.initialized) {
+      if (a.state === b.state) {
         return a.displayName?.localeCompare(b.displayName as string) ?? 0;
       }
-      return a.initialized ? 1 : -1;
+      return b.state?.localeCompare(a.state as string) ?? 0;
     };
     const { result } = renderHook(() => useIModelSort(iModels, sortFn));
     expect(result.current).not.toBe(iModels);
@@ -171,27 +171,27 @@ describe("useIModelSort hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     const { result } = renderHook(() => useIModelSort(iModels, undefined));
@@ -203,27 +203,27 @@ describe("useIModelSort hook", () => {
       {
         id: "1",
         displayName: "c",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "2",
         displayName: "a",
-        initialized: true,
+        state: "initialized",
       },
       {
         id: "3",
         displayName: "e",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "4",
         displayName: "d",
-        initialized: false,
+        state: "notInitialized",
       },
       {
         id: "5",
         displayName: "b",
-        initialized: true,
+        state: "initialized",
       },
     ];
     const { result } = renderHook(() =>

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelSort.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelSort.ts
@@ -16,13 +16,9 @@ function isSupportedSortType(
 ): sortType is IModelSortOptionsKeys {
   return (
     !!sortType &&
-    [
-      "displayName",
-      "name",
-      "description",
-      "initialized",
-      "createdDateTime",
-    ].includes(sortType)
+    ["displayName", "name", "description", "state", "createdDateTime"].includes(
+      sortType
+    )
   );
 }
 

--- a/packages/modules/imodel-browser/src/containers/iModelThumbnail/useIModelThumbnail.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelThumbnail/useIModelThumbnail.ts
@@ -7,10 +7,6 @@ import { useEffect, useState } from "react";
 import { ApiOverrides } from "../../types";
 import { _getAPIServer } from "../../utils/_apiOverrides";
 
-const cache: {
-  [iModelId: string]: string;
-} = {};
-
 /** Convert buffer response to URL format: data:image/png;base64 */
 function convertArrayBufferToUrlBase64PNG(buffer: ArrayBuffer) {
   const byteArray = new Uint8Array(buffer);
@@ -30,7 +26,7 @@ export const useIModelThumbnail = (
   accessToken?: string,
   apiOverrides?: ApiOverrides<string>
 ) => {
-  const [thumbnail, setThumbnail] = useState(cache[iModelId]);
+  const [thumbnail, setThumbnail] = useState<string>();
   useEffect(() => {
     if (apiOverrides?.data) {
       setThumbnail(apiOverrides.data);
@@ -62,7 +58,6 @@ export const useIModelThumbnail = (
         })
         .then((thumbnail: string) => {
           setThumbnail(thumbnail);
-          cache[iModelId] = thumbnail;
         })
         .catch((e) => {
           if (e.name === "AbortError") {

--- a/packages/modules/imodel-browser/src/tests/mocks/handlers.ts
+++ b/packages/modules/imodel-browser/src/tests/mocks/handlers.ts
@@ -19,6 +19,20 @@ export const handlers = [
     );
   }),
   rest.get("https://api.bentley.com/projects/", (req, res, ctx) => {
+    const search = req.url.searchParams.get("$search");
+    if (search === "searched") {
+      return res(
+        ctx.status(200),
+        ctx.json({
+          projects: [
+            {
+              id: "my1",
+              displayName: "mySearchediModel",
+            },
+          ],
+        })
+      );
+    }
     return res(
       ctx.status(200),
       ctx.json({

--- a/packages/modules/imodel-browser/src/types.ts
+++ b/packages/modules/imodel-browser/src/types.ts
@@ -16,8 +16,8 @@ export interface IModelFull {
   /** "Description of the iModel." */
   description?: string | null;
 
-  /** "Boolean flag indicating when iModel is ready to be used." */
-  initialized?: boolean;
+  /** "Enum indicating when iModel is ready to be used." */
+  state?: "initialized" | "notInitialized";
 
   /** "Date when the iModel was created." */
   createdDateTime?: string;
@@ -83,7 +83,7 @@ export type IModelSortOptionsKeys =
   | "displayName"
   | "name"
   | "description"
-  | "initialized"
+  | "state"
   | "createdDateTime";
 
 /** Object/function that configure IModel sorting behavior. */


### PR DESCRIPTION
# Create-iModel package

Only changed the IModelFull type which replaces `initialized: boolean` property with `state: "initialized" | "notInitialized";`. (Changes in APIM are meant to be PR'd tomorrow.)

# iModel-Browser package

Same changes as above for IModelFull.

## IModelThumbnails caching

Removed the local caching of iModel thumbnails, this will address an issue where the thumbnail can now be edited by create-imodel package and these changes werent reflected by the browser. It was also an issue if the thumbnails were edited anywhere else actually, so I removed this caching and will let the network handle the caching itself.

## ProjectGrid requestType

Added a new `search=` requestType, which is to be used as `search=Name`. TS 4.1 typings for the values would be:

    requestType?: "favorites" | "recents" | `search=${string}` | "";

As I dont want to use 4.1 typings because TS 4.1 is not a hard requirement, the actual typing is this:

    requestType?: "favorites" | "recents" | "" | string;

Because of which I now validate the `requestType` prop have a known value/template.

Fixed a message error when no projects could be found.
