### PR TITLE
Remove iModelGrid thumbnail cache

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/raplemie-removeThumbnailCache_2021-08-04-14-26.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-removeThumbnailCache_2021-08-04-14-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Disable iModel thumbnail caching and leave it to the network",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelThumbnail/useIModelThumbnail.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelThumbnail/useIModelThumbnail.ts
@@ -7,10 +7,6 @@ import { useEffect, useState } from "react";
 import { ApiOverrides } from "../../types";
 import { _getAPIServer } from "../../utils/_apiOverrides";
 
-const cache: {
-  [iModelId: string]: string;
-} = {};
-
 /** Convert buffer response to URL format: data:image/png;base64 */
 function convertArrayBufferToUrlBase64PNG(buffer: ArrayBuffer) {
   const byteArray = new Uint8Array(buffer);
@@ -30,7 +26,7 @@ export const useIModelThumbnail = (
   accessToken?: string,
   apiOverrides?: ApiOverrides<string>
 ) => {
-  const [thumbnail, setThumbnail] = useState(cache[iModelId]);
+  const [thumbnail, setThumbnail] = useState<string>();
   useEffect(() => {
     if (apiOverrides?.data) {
       setThumbnail(apiOverrides.data);
@@ -62,7 +58,6 @@ export const useIModelThumbnail = (
         })
         .then((thumbnail: string) => {
           setThumbnail(thumbnail);
-          cache[iModelId] = thumbnail;
         })
         .catch((e) => {
           if (e.name === "AbortError") {


### PR DESCRIPTION
# IModelThumbnails caching

Removed the local caching of iModel thumbnails, this will address an issue where the thumbnail can now be edited by create-imodel package and these changes werent reflected by the browser. It was also an issue if the thumbnails were edited anywhere else actually, so I removed this caching and will let the network handle the caching itself.
