### PR TITLE
Fix READMEs when displayed in npm

### DIFF
--- a/common/changes/@itwin/create-imodel-react/raplemie-readmefixes_2021-08-04-15-46.json
+++ b/common/changes/@itwin/create-imodel-react/raplemie-readmefixes_2021-08-04-15-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/create-imodel-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/create-imodel-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/delete-imodel-react/raplemie-readmefixes_2021-08-04-15-46.json
+++ b/common/changes/@itwin/delete-imodel-react/raplemie-readmefixes_2021-08-04-15-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/delete-imodel-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/delete-imodel-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/imodel-browser-react/raplemie-readmefixes_2021-08-04-15-46.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-readmefixes_2021-08-04-15-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/manage-versions-react/raplemie-readmefixes_2021-08-04-15-46.json
+++ b/common/changes/@itwin/manage-versions-react/raplemie-readmefixes_2021-08-04-15-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/modules/create-imodel/README.md
+++ b/packages/modules/create-imodel/README.md
@@ -10,4 +10,4 @@ When making changes to the src, run `rushx start` in the dev folder to enable so
 
 # Changelog
 
-See complete CHANGELOG [here](./CHANGELOG.md)
+See complete CHANGELOG [here](https://github.com/iTwin/admin-components-react/blob/main/packages/modules/create-imodel/CHANGELOG.md)

--- a/packages/modules/delete-imodel/README.md
+++ b/packages/modules/delete-imodel/README.md
@@ -10,4 +10,4 @@ When making changes to the src, run `rushx start` in the dev folder to enable so
 
 # Changelog
 
-See complete CHANGELOG [here](./CHANGELOG.md)
+See complete CHANGELOG [here](https://github.com/iTwin/admin-components-react/blob/main/packages/modules/delete-imodel/CHANGELOG.md)

--- a/packages/modules/imodel-browser/README.md
+++ b/packages/modules/imodel-browser/README.md
@@ -4,15 +4,10 @@ Contains components that let the user browse the iModels of a context and select
 
 Consider this package as unstable until 1.0 release.
 
-Note: this package is published internally but with the @itwin scope, it might be required to add the following lines to a `.npmrc` file.
-
-    @itwin:registry=https://pkgs.dev.azure.com/bentleycs/_packaging/Packages/npm/registry/
-    always-auth=true
-
 # Development
 
-When making changes to the src, run `rushx start` in the dev folder to enable source watching and rebuild, so the storybook dev-server will have access to updated code on succesful code compilation.
+When making changes to the src, run `rushx start` in the dev folder to enable source watching and rebuild, so the storybook dev-server will have access to updated code on successful code compilation.
 
 # Changelog
 
-See complete CHANGELOG [here](./CHANGELOG.md)
+See complete CHANGELOG [here](https://github.com/iTwin/admin-components-react/blob/main/packages/modules/imodel-browser/CHANGELOG.md)

--- a/packages/modules/manage-versions/README.md
+++ b/packages/modules/manage-versions/README.md
@@ -35,4 +35,4 @@ When making changes to the src, run `rushx start` in the dev folder to enable so
 
 ## Changelog
 
-See complete CHANGELOG [here](./CHANGELOG.md)
+See complete CHANGELOG [here](https://github.com/iTwin/admin-components-react/blob/main/packages/modules/manage-versions/CHANGELOG.md)

--- a/packages/modules/manage-versions/package.json
+++ b/packages/modules/manage-versions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itwin/manage-versions-react",
   "description": "Components that allow a user to manage Named Versions and Changesets.",
-  "repository": "https://github.com/iTwin/admin-components-react/tree/main/package/manage-versions",
+  "repository": "https://github.com/iTwin/admin-components-react/tree/main/packages/modules/manage-versions",
   "version": "0.7.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
README.md "Changelog" link are pointing to ./Changelog.md, which do not work correctly when displayed in npm.