### PR TITLE
post process callbacks

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/raplemie-postProcessCallback_2021-08-09-19-01.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-postProcessCallback_2021-08-09-19-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Add `postProcessingCallback` property to `*Grid` components",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/apps/storybook/src/imodel-browser/ProjectGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ProjectGrid.stories.tsx
@@ -3,16 +3,20 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import {
+  DataStatus,
   IndividualProjectStateHook,
+  ProjectFull,
   ProjectGrid as ExternalComponent,
   ProjectGridProps,
 } from "@itwin/imodel-browser-react";
 import {
+  Body,
   Button,
   Code,
   DropdownButton,
   MenuItem,
   TileProps,
+  Title,
 } from "@itwin/itwinui-react";
 import { Meta, Story } from "@storybook/react/types-6-0";
 import React, { PropsWithChildren } from "react";
@@ -63,7 +67,7 @@ OverrideApiData.args = {
 export const IndividualContextMenu = Template.bind({});
 IndividualContextMenu.args = {
   apiOverrides: { serverEnvironmentPrefix: "qa" },
-  projectOptions: [
+  projectActions: [
     {
       children: "displayName contains 'R'",
       visible: (project) => project.displayName?.includes("R") ?? false,
@@ -257,4 +261,37 @@ export const StatefulPropsOverrides = Template.bind({});
 StatefulPropsOverrides.args = {
   apiOverrides: { serverEnvironmentPrefix: "qa" },
   useIndividualState,
+};
+
+export const WithPostProcessCallback: Story<ProjectGridProps> = withAccessTokenOverride(
+  (args) => {
+    const addStartTile = React.useCallback(
+      (projects: ProjectFull[], status: DataStatus) => {
+        if (status !== DataStatus.Complete) {
+          return projects;
+        }
+        projects.unshift({
+          id: "newProject",
+          displayName: "New Project",
+          projectNumber: "Click on this tile to create a new Project",
+        });
+        return projects;
+      },
+      []
+    );
+    return (
+      <div>
+        <Title>Description</Title>
+        <Body>
+          Property <Code>postProcessCallback</Code> allows modification of the
+          data that is sent to the grid, here, we add a new tile at the start of
+          the list for a 'New Project'.
+        </Body>
+        <ProjectGrid {...args} postProcessCallback={addStartTile} />
+      </div>
+    );
+  }
+);
+WithPostProcessCallback.args = {
+  apiOverrides: { serverEnvironmentPrefix: "qa" },
 };

--- a/packages/modules/imodel-browser/src/containers/ProjectGrid/ProjectGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ProjectGrid/ProjectGrid.tsx
@@ -64,7 +64,7 @@ export interface ProjectGridProps {
    */
   apiOverrides?: ApiOverrides<ProjectFull[]>;
   /**
-   * Allow final transformation of the iModel array before display
+   * Allow final transformation of the project array before display
    * This function MUST be memoized.
    */
   postProcessCallback?: (

--- a/packages/modules/imodel-browser/src/containers/ProjectGrid/ProjectGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ProjectGrid/ProjectGrid.tsx
@@ -63,6 +63,14 @@ export interface ProjectGridProps {
    * @property `serverEnvironmentPrefix`: Either qa or dev.
    */
   apiOverrides?: ApiOverrides<ProjectFull[]>;
+  /**
+   * Allow final transformation of the iModel array before display
+   * This function MUST be memoized.
+   */
+  postProcessCallback?: (
+    projects: ProjectFull[],
+    fetchStatus: DataStatus | undefined
+  ) => ProjectFull[];
 }
 
 /**
@@ -78,6 +86,7 @@ export const ProjectGrid = ({
   stringsOverrides,
   tileOverrides,
   useIndividualState,
+  postProcessCallback,
 }: ProjectGridProps) => {
   const strings = _mergeStrings(
     {
@@ -89,12 +98,23 @@ export const ProjectGrid = ({
     },
     stringsOverrides
   );
-  const { projects, status: fetchStatus, fetchMore } = useProjectData({
+  const {
+    projects: fetchedProjects,
+    status: fetchStatus,
+    fetchMore,
+  } = useProjectData({
     requestType,
     accessToken,
     apiOverrides,
     filterOptions,
   });
+
+  const projects = React.useMemo(
+    () =>
+      postProcessCallback?.([...fetchedProjects], fetchStatus) ??
+      fetchedProjects,
+    [postProcessCallback, fetchedProjects, fetchStatus]
+  );
 
   const noResultsText = {
     [DataStatus.Fetching]: "",

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -57,6 +57,14 @@ export interface IModelGridProps {
    * @property `serverEnvironmentPrefix`: Either qa or dev.
    */
   apiOverrides?: ApiOverrides<IModelFull[]>;
+  /**
+   * Allow final transformation of the iModel array before display
+   * This function MUST be memoized.
+   */
+  postProcessCallback?: (
+    iModels: IModelFull[],
+    fetchStatus: DataStatus | undefined
+  ) => IModelFull[];
 }
 
 /**
@@ -72,6 +80,7 @@ export const IModelGrid = ({
   stringsOverrides,
   tileOverrides,
   useIndividualState,
+  postProcessCallback,
 }: IModelGridProps) => {
   const strings = _mergeStrings(
     {
@@ -82,12 +91,21 @@ export const IModelGrid = ({
     },
     stringsOverrides
   );
-  const { iModels, status: fetchStatus, fetchMore } = useIModelData({
+  const {
+    iModels: fetchediModels,
+    status: fetchStatus,
+    fetchMore,
+  } = useIModelData({
     accessToken,
     apiOverrides,
     projectId,
     sortOptions,
   });
+  const iModels = React.useMemo(
+    () =>
+      postProcessCallback?.([...fetchediModels], fetchStatus) ?? fetchediModels,
+    [postProcessCallback, fetchediModels, fetchStatus]
+  );
 
   const noResultsText = {
     [DataStatus.Fetching]: "",


### PR DESCRIPTION
# Post Process Callbacks

Adding `postProcessCallback` prop to the 2 grids component, this will allow users to take action on the fetched data, allowing modification (sorting, adding or deleting elements) without us having to handle these, allowing us on focusing on the REST API's features only.