### PR TITLE
Added Content-Type header to POST and PATCH requests

### DIFF
--- a/common/changes/@itwin/create-imodel-react/vilius-content-type_2021-08-10-10-55.json
+++ b/common/changes/@itwin/create-imodel-react/vilius-content-type_2021-08-10-10-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/create-imodel-react",
+      "comment": "Setting Content-Type header for POST and PATCH requests.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/create-imodel-react",
+  "email": "36186912+bentleyvk@users.noreply.github.com"
+}

--- a/packages/modules/create-imodel/src/components/create-imodel/CreateIModel.test.tsx
+++ b/packages/modules/create-imodel/src/components/create-imodel/CreateIModel.test.tsx
@@ -50,7 +50,11 @@ describe("CreateIModel", () => {
       "https://dev-api.bentley.com/imodels",
       {
         method: "POST",
-        headers: { Authorization: "dd", Prefer: "return=representation" },
+        headers: {
+          Authorization: "dd",
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           projectId: "de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
           name: "Some name",
@@ -93,7 +97,11 @@ describe("CreateIModel", () => {
       "https://dev-api.bentley.com/imodels",
       {
         method: "POST",
-        headers: { Authorization: "dd", Prefer: "return=representation" },
+        headers: {
+          Authorization: "dd",
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           projectId: "de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
           name: "Some name",
@@ -136,7 +144,11 @@ describe("CreateIModel", () => {
       "https://dev-api.bentley.com/imodels",
       {
         method: "POST",
-        headers: { Authorization: "dd", Prefer: "return=representation" },
+        headers: {
+          Authorization: "dd",
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           projectId: "de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
           name: "Some name",

--- a/packages/modules/create-imodel/src/components/create-imodel/CreateIModel.tsx
+++ b/packages/modules/create-imodel/src/components/create-imodel/CreateIModel.tsx
@@ -84,6 +84,7 @@ export function CreateIModel(props: CreateIModelProps) {
         headers: {
           Authorization: `${accessToken}`,
           Prefer: "return=representation",
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           projectId,

--- a/packages/modules/create-imodel/src/components/update-imodel/UpdateIModel.test.tsx
+++ b/packages/modules/create-imodel/src/components/update-imodel/UpdateIModel.test.tsx
@@ -54,7 +54,11 @@ describe("UpdateIModel", () => {
       "https://dev-api.bentley.com/imodels/de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
       {
         method: "PATCH",
-        headers: { Authorization: "dd", Prefer: "return=representation" },
+        headers: {
+          Authorization: "dd",
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           name: "Some other name",
           description: "Initial description",
@@ -100,7 +104,11 @@ describe("UpdateIModel", () => {
       "https://dev-api.bentley.com/imodels/de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
       {
         method: "PATCH",
-        headers: { Authorization: "dd", Prefer: "return=representation" },
+        headers: {
+          Authorization: "dd",
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           name: "Some name",
           description: "Initial description",
@@ -146,7 +154,11 @@ describe("UpdateIModel", () => {
       "https://dev-api.bentley.com/imodels/de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
       {
         method: "PATCH",
-        headers: { Authorization: "dd", Prefer: "return=representation" },
+        headers: {
+          Authorization: "dd",
+          Prefer: "return=representation",
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({
           name: "Some name",
           description: "Initial description",

--- a/packages/modules/create-imodel/src/components/update-imodel/UpdateIModel.tsx
+++ b/packages/modules/create-imodel/src/components/update-imodel/UpdateIModel.tsx
@@ -89,6 +89,7 @@ export function UpdateIModel(props: UpdateIModelProps) {
         headers: {
           Authorization: `${accessToken}`,
           Prefer: "return=representation",
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           name: imodel.name,


### PR DESCRIPTION
iModel Hub in APIM is planning to validate Content-Type headers. So added it in places where it was missing.