### PR TITLE
Moved `ManageVersionsTabs` to regular exports so it could be used when setting `currentTab`.

### DIFF
--- a/common/changes/@itwin/manage-versions-react/vilius-tab-enum-fix_2021-08-11-05-37.json
+++ b/common/changes/@itwin/manage-versions-react/vilius-tab-enum-fix_2021-08-11-05-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "Moved `ManageVersionsTabs` to regular exports so it could be used when setting `currentTab`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react",
+  "email": "36186912+bentleyvk@users.noreply.github.com"
+}

--- a/packages/modules/manage-versions/src/index.ts
+++ b/packages/modules/manage-versions/src/index.ts
@@ -2,11 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export { ManageVersions } from "./components/ManageVersions/ManageVersions";
-export type {
-  ManageVersionsProps,
+export {
+  ManageVersions,
   ManageVersionsTabs,
 } from "./components/ManageVersions/ManageVersions";
+export type { ManageVersionsProps } from "./components/ManageVersions/ManageVersions";
 
 export type {
   ApiOverrides,


### PR DESCRIPTION
![MicrosoftTeams-image (17)](https://user-images.githubusercontent.com/36186912/128975346-2da4192b-5929-44cf-8792-0c621cdad537.png)
