### PR TITLE
Raplemie/remove webfont use

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/raplemie-removeWebfontUse_2021-08-11-17-49.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-removeWebfontUse_2021-08-11-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Use @itwin/itwinui-icons-react instead of @bentley/icons-generic-webfont",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/modules/imodel-browser/package.json
+++ b/packages/modules/imodel-browser/package.json
@@ -19,8 +19,8 @@
     "esm/**/*"
   ],
   "dependencies": {
-    "@bentley/icons-generic-webfont": "^1.0.34",
     "classnames": "^2.2.6",
+    "@itwin/itwinui-icons-react": "^1.2.0",
     "@itwin/itwinui-react": "^1.11.0",
     "react-intersection-observer": "^8.31.1"
   },

--- a/packages/modules/imodel-browser/rollup.config.js
+++ b/packages/modules/imodel-browser/rollup.config.js
@@ -13,12 +13,9 @@ import * as packageJson from "./package.json";
 
 const rollupConfig = {
   input: "src/index.ts",
-  external: [
-    /@itwin\/itwinui-react(\/.*)?/,
-    /classnames/,
-    /@bentley\/icons-generic-webfont/,
-    /react-intersection-observer/,
-  ],
+  external: Object.keys(packageJson.dependencies).map(
+    (dep) => new RegExp(`${dep}(/.*)?`, "g")
+  ),
   output: [
     {
       file: packageJson.main,

--- a/packages/modules/imodel-browser/src/components/noResults/NoResults.scss
+++ b/packages/modules/imodel-browser/src/components/noResults/NoResults.scss
@@ -17,8 +17,9 @@
   margin-top: $iui-m;
   margin-bottom: $iui-m;
 
-  > i {
-    font-size: 75px;
+  > svg {
+    height: 75px;
+    fill: currentColor;
   }
 
   > span:first-of-type {

--- a/packages/modules/imodel-browser/src/components/noResults/NoResults.tsx
+++ b/packages/modules/imodel-browser/src/components/noResults/NoResults.tsx
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import "./NoResults.scss";
-import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 
+import { SvgImodelHollow } from "@itwin/itwinui-icons-react";
 import { Leading } from "@itwin/itwinui-react";
 import classnames from "classnames";
 import React from "react";
@@ -18,7 +18,7 @@ export interface NoResultsProps {
 export const NoResults = ({ text }: NoResultsProps) => {
   return (
     <Leading isMuted={true} className={classnames("iac-no-results")}>
-      <i className="icon icon-imodel-hollow-2" />
+      <SvgImodelHollow />
       <span>{text}</span>
     </Leading>
   );

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
-
 import React from "react";
 import { InView } from "react-intersection-observer";
 


### PR DESCRIPTION
# @itwin/imodel-browser-react

The package was using @bentley/icons-generic-webfont, however this package is doing behind the scene stuff that is a bit hard to debug when it does not work. As I only use 1 icon for the NoResults component, I removed its use and replaced it with the more convenient @itwin/itwinui-icons-react package, which offer the same icon as a react component.