### PR TITLE
Remove page management if data is provided.

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/raplemie-fixMorePageWithDataOverrides_2022-06-02-16-34.json
+++ b/common/changes/@itwin/imodel-browser-react/raplemie-fixMorePageWithDataOverrides_2022-06-02-16-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix trailing ghost cards when using `apiOverrides.data` prop.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.test.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.test.ts
@@ -85,6 +85,7 @@ describe("useIModelData hook", () => {
 
     expect(result.current.iModels).toEqual([]);
     expect(result.current.status).toEqual(DataStatus.Complete);
+    expect(result.current.fetchMore).toBeUndefined();
     expect(watcher).toHaveBeenCalledTimes(1);
 
     rerender([
@@ -106,6 +107,7 @@ describe("useIModelData hook", () => {
 
     expect(result.current.iModels).toEqual([]);
     expect(result.current.status).toEqual(DataStatus.Complete);
+    expect(result.current.fetchMore).toBeUndefined();
     expect(watcher).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -62,6 +62,7 @@ export const useIModelData = ({
     if (apiOverrides?.data) {
       setIModels(apiOverrides.data);
       setStatus(DataStatus.Complete);
+      setMorePages(false);
       return;
     }
     if (!accessToken || !projectId) {


### PR DESCRIPTION
# BugFix

When the `data` is provided by the user using the `apiOverrides`, we are still showing the trailing cards for the "fetch more", however these are never correctly removed.

So whenever we have this type of data provided, we now disable that paging mechanism. (A further enhancement could be to allow that paging to happen with this data, however now that https://www.npmjs.com/package/@itwin/itwinui-layouts-react exists and provide a grid itself, I'm not sure it is worth adding features to this aspect of the IModelGrid.