### PR TITLE
Use iModel API v2 for iTwin iModels

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/wkb-itwin-imodels_2023-01-19-15-29.json
+++ b/common/changes/@itwin/imodel-browser-react/wkb-itwin-imodels_2023-01-19-15-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Use iModels API v2 for iTwin iModels",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -77,7 +77,7 @@ export const useIModelData = ({
     }
     const abortController = new AbortController();
 
-    const selection = `?projectId=${projectId}`;
+    const selection = `?iTwinId=${projectId}`;
     const sorting = sortType
       ? `&$orderBy=${sortType} ${sortDescending ? "desc" : "asc"}`
       : "";
@@ -91,6 +91,7 @@ export const useIModelData = ({
       headers: {
         Authorization: accessToken,
         Prefer: "return=representation",
+        Accept: "application/vnd.bentley.itwin-platform.v2+json",
       },
     };
     fetch(url, options)


### PR DESCRIPTION
- Use iModel API v2
- Backwards compatible, so still works with projects