### PR TITLE
Added registerBy to ProjectFull

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/wkb-add-reg-by_2023-02-14-13-44.json
+++ b/common/changes/@itwin/imodel-browser-react/wkb-add-reg-by_2023-02-14-13-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Added registeredBy to ProjectFull",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/types.ts
+++ b/packages/modules/imodel-browser/src/types.ts
@@ -38,6 +38,7 @@ export interface ProjectFull {
   displayName?: string;
   projectNumber?: string;
   registrationDateTime?: string;
+  registeredBy?: string;
   industry?: string;
   projectType?: string;
   geographicLocation?: string;


### PR DESCRIPTION
- Added missing property to `ProjectFull`
- Useful in the following scenarios:
    - Only show Projects the user has created
    - Only allow editing of projects created by a certain user
    - Add a little "Mine" badge to Projects the user created
    - Etc...