### PR TITLE
Added Changed Files column to the changes tab table

### DIFF
--- a/common/changes/@itwin/manage-versions-react/changedFilesColumn_2023-02-21-12-05.json
+++ b/common/changes/@itwin/manage-versions-react/changedFilesColumn_2023-02-21-12-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/manage-versions-react",
-      "comment": "Added optional prop to show changed files column in changes tab table",
+      "comment": "Added changed files column in changes tab table",
       "type": "minor"
     }
   ],

--- a/common/changes/@itwin/manage-versions-react/changedFilesColumn_2023-02-21-12-05.json
+++ b/common/changes/@itwin/manage-versions-react/changedFilesColumn_2023-02-21-12-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "Added optional prop to show changed files column in changes tab table",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react"
+}

--- a/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.test.tsx
@@ -39,15 +39,18 @@ describe("ChangesTab", () => {
 
     rows.forEach((row, index) => {
       const cells = row.querySelectorAll(".iui-cell");
-      expect(cells.length).toBe(4);
+      expect(cells.length).toBe(5);
       expect(cells[0].textContent).toContain(MockedChangeset(index).index);
       expect(cells[1].textContent).toContain(
         MockedChangeset(index).description
       );
       expect(cells[2].textContent).toContain(
+        MockedChangeset(index).synchronizationInfo.changedFiles.join(", ")
+      );
+      expect(cells[3].textContent).toContain(
         new Date(MockedChangeset(index).pushDateTime).toLocaleString()
       );
-      within(cells[3] as HTMLElement).getByTitle(
+      within(cells[4] as HTMLElement).getByTitle(
         defaultStrings.createNamedVersion
       );
     });

--- a/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
@@ -20,7 +20,6 @@ export type ChangesTabProps = {
   loadMoreChanges: () => void;
   onVersionCreated: () => void;
   latestVersion: NamedVersion | undefined;
-  shouldShowChangedFiles?: boolean;
 };
 
 const ChangesTab = (props: ChangesTabProps) => {
@@ -67,11 +66,7 @@ const ChangesTab = (props: ChangesTabProps) => {
             Cell: (props: CellProps<Changeset>) => {
               const changedFiles =
                 props.row.original.synchronizationInfo.changedFiles;
-              return (
-                <span>
-                  {changedFiles?.length ? changedFiles.join(",") : ""}
-                </span>
-              );
+              return changedFiles?.length ? changedFiles.join(", ") : "";
             },
           },
           {
@@ -130,14 +125,6 @@ const ChangesTab = (props: ChangesTabProps) => {
     stringsOverrides.messageNoChanges,
   ]);
 
-  const hiddenColumns = React.useMemo(() => {
-    const hiddenColumns = [];
-    if (!props.shouldShowChangedFiles) {
-      hiddenColumns.push("CHANGED_FILES");
-    }
-    return hiddenColumns;
-  }, [props.shouldShowChangedFiles]);
-
   return (
     <>
       <Table<Changeset>
@@ -150,7 +137,6 @@ const ChangesTab = (props: ChangesTabProps) => {
         emptyTableContent={emptyTableContent}
         onBottomReached={loadMoreChanges}
         className="iac-changes-table"
-        initialState={{ hiddenColumns }}
       />
       {isCreateVersionModalOpen && (
         <CreateVersionModal

--- a/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
@@ -20,6 +20,7 @@ export type ChangesTabProps = {
   loadMoreChanges: () => void;
   onVersionCreated: () => void;
   latestVersion: NamedVersion | undefined;
+  shouldShowChangedFiles?: boolean;
 };
 
 const ChangesTab = (props: ChangesTabProps) => {
@@ -33,10 +34,8 @@ const ChangesTab = (props: ChangesTabProps) => {
 
   const { stringsOverrides } = useConfig();
 
-  const [
-    isCreateVersionModalOpen,
-    setIsCreateVersionModalOpen,
-  ] = React.useState(false);
+  const [isCreateVersionModalOpen, setIsCreateVersionModalOpen] =
+    React.useState(false);
 
   const [currentChangeset, setCurrentChangeset] = React.useState<
     Changeset | undefined
@@ -61,6 +60,19 @@ const ChangesTab = (props: ChangesTabProps) => {
             id: "DESCRIPTION",
             Header: stringsOverrides.description,
             accessor: "description",
+          },
+          {
+            id: "CHANGED_FILES",
+            Header: stringsOverrides.changedFiles,
+            Cell: (props: CellProps<Changeset>) => {
+              const changedFiles =
+                props.row.original.synchronizationInfo.changedFiles;
+              return (
+                <span>
+                  {changedFiles?.length ? changedFiles.join(",") : ""}
+                </span>
+              );
+            },
           },
           {
             id: "PUSH_DATE",
@@ -118,6 +130,14 @@ const ChangesTab = (props: ChangesTabProps) => {
     stringsOverrides.messageNoChanges,
   ]);
 
+  const hiddenColumns = React.useMemo(() => {
+    const hiddenColumns = [];
+    if (!props.shouldShowChangedFiles) {
+      hiddenColumns.push("CHANGED_FILES");
+    }
+    return hiddenColumns;
+  }, [props.shouldShowChangedFiles]);
+
   return (
     <>
       <Table<Changeset>
@@ -130,6 +150,7 @@ const ChangesTab = (props: ChangesTabProps) => {
         emptyTableContent={emptyTableContent}
         onBottomReached={loadMoreChanges}
         className="iac-changes-table"
+        initialState={{ hiddenColumns }}
       />
       {isCreateVersionModalOpen && (
         <CreateVersionModal

--- a/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
@@ -65,7 +65,7 @@ const ChangesTab = (props: ChangesTabProps) => {
             Header: stringsOverrides.changedFiles,
             Cell: (props: CellProps<Changeset>) => {
               const changedFiles =
-                props.row.original.synchronizationInfo.changedFiles;
+                props.row.original.synchronizationInfo?.changedFiles;
               return changedFiles?.length ? changedFiles.join(", ") : "";
             },
           },
@@ -110,6 +110,7 @@ const ChangesTab = (props: ChangesTabProps) => {
     ];
   }, [
     canCreateVersion,
+    stringsOverrides.changedFiles,
     stringsOverrides.createNamedVersion,
     stringsOverrides.description,
     stringsOverrides.time,

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
@@ -86,12 +86,15 @@ describe("ManageVersions", () => {
 
     changesetRows.forEach((row, index) => {
       const cells = row.querySelectorAll(".iui-cell");
-      expect(cells.length).toBe(4);
+      expect(cells.length).toBe(5);
       expect(cells[0].textContent).toContain(MockedChangeset(index).index);
       expect(cells[1].textContent).toContain(
         MockedChangeset(index).description
       );
       expect(cells[2].textContent).toContain(
+        MockedChangeset(index).synchronizationInfo.changedFiles.join(", ")
+      );
+      expect(cells[3].textContent).toContain(
         new Date(MockedChangeset(index).pushDateTime).toLocaleString()
       );
     });
@@ -270,10 +273,13 @@ it("should render with changesets tab opened", async () => {
 
   changesetRows.forEach((row, index) => {
     const cells = row.querySelectorAll(".iui-cell");
-    expect(cells.length).toBe(4);
+    expect(cells.length).toBe(5);
     expect(cells[0].textContent).toContain(MockedChangeset(index).index);
     expect(cells[1].textContent).toContain(MockedChangeset(index).description);
     expect(cells[2].textContent).toContain(
+      MockedChangeset(index).synchronizationInfo.changedFiles.join(", ")
+    );
+    expect(cells[3].textContent).toContain(
       new Date(MockedChangeset(index).pushDateTime).toLocaleString()
     );
   });

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -70,8 +70,6 @@ export type ManageVersionsProps = {
   currentTab?: ManageVersionsTabs;
   /** Callback when tabs are switched. */
   onTabChange?: (tab: ManageVersionsTabs) => void;
-  /** flag to show/hide changed files column in changes tab */
-  shouldShowChangedFiles?: boolean;
 };
 
 export enum ManageVersionsTabs {
@@ -92,7 +90,6 @@ export const ManageVersions = (props: ManageVersionsProps) => {
     onViewClick,
     currentTab = ManageVersionsTabs.Versions,
     onTabChange,
-    shouldShowChangedFiles,
   } = props;
 
   const versionClient = React.useMemo(
@@ -246,7 +243,6 @@ export const ManageVersions = (props: ManageVersionsProps) => {
             loadMoreChanges={getChangesets}
             onVersionCreated={onVersionCreated}
             latestVersion={latestVersion}
-            shouldShowChangedFiles={shouldShowChangedFiles}
           />
         )}
       </div>

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -24,6 +24,7 @@ export const defaultStrings: ManageVersionsStringOverrides = {
   name: "Name",
   description: "Description",
   time: "Time",
+  changedFiles: "Changed Files",
   createNamedVersion: "Create a Named Version",
   cancel: "Cancel",
   create: "Create",
@@ -69,6 +70,8 @@ export type ManageVersionsProps = {
   currentTab?: ManageVersionsTabs;
   /** Callback when tabs are switched. */
   onTabChange?: (tab: ManageVersionsTabs) => void;
+  /** flag to show/hide changed files column in changes tab */
+  shouldShowChangedFiles?: boolean;
 };
 
 export enum ManageVersionsTabs {
@@ -89,6 +92,7 @@ export const ManageVersions = (props: ManageVersionsProps) => {
     onViewClick,
     currentTab = ManageVersionsTabs.Versions,
     onTabChange,
+    shouldShowChangedFiles,
   } = props;
 
   const versionClient = React.useMemo(
@@ -242,6 +246,7 @@ export const ManageVersions = (props: ManageVersionsProps) => {
             loadMoreChanges={getChangesets}
             onVersionCreated={onVersionCreated}
             latestVersion={latestVersion}
+            shouldShowChangedFiles={shouldShowChangedFiles}
           />
         )}
       </div>

--- a/packages/modules/manage-versions/src/components/ManageVersions/types.ts
+++ b/packages/modules/manage-versions/src/components/ManageVersions/types.ts
@@ -20,6 +20,8 @@ export type ManageVersionsStringOverrides = {
   description: string;
   /** Table column title for time. Default `Time`. */
   time: string;
+  /** Table column title for changed files. Default `Changed Files`. */
+  changedFiles: string;
   /** Title for Named Version create modal. Default `Create a Named Version` */
   createNamedVersion: string;
   /** Default: `Cancel` */

--- a/packages/modules/manage-versions/src/mocks.ts
+++ b/packages/modules/manage-versions/src/mocks.ts
@@ -48,7 +48,7 @@ export const MockedChangeset = (
     displayName: `${index}`,
     description: `ch_description${index}`,
     pushDateTime: MOCKED_DATE,
-    synchronizationInfo: { changedFiles: ["test"] },
+    synchronizationInfo: { changedFiles: ["test-file-${index}.dgn"] },
     _links: {},
     ...props,
   };

--- a/packages/modules/manage-versions/src/mocks.ts
+++ b/packages/modules/manage-versions/src/mocks.ts
@@ -48,7 +48,7 @@ export const MockedChangeset = (
     displayName: `${index}`,
     description: `ch_description${index}`,
     pushDateTime: MOCKED_DATE,
-    synchronizationInfo: { changedFiles: ["test-file-${index}.dgn"] },
+    synchronizationInfo: { changedFiles: [`test-file-${index}.dgn`] },
     _links: {},
     ...props,
   };

--- a/packages/modules/manage-versions/src/mocks.ts
+++ b/packages/modules/manage-versions/src/mocks.ts
@@ -48,6 +48,7 @@ export const MockedChangeset = (
     displayName: `${index}`,
     description: `ch_description${index}`,
     pushDateTime: MOCKED_DATE,
+    synchronizationInfo: { changedFiles: ["test"] },
     _links: {},
     ...props,
   };

--- a/packages/modules/manage-versions/src/models/changeset.ts
+++ b/packages/modules/manage-versions/src/models/changeset.ts
@@ -8,6 +8,9 @@ export type Changeset = {
   description: string;
   index: string;
   pushDateTime: string;
+  synchronizationInfo: {
+    changedFiles: string[];
+  };
   _links: {
     namedVersion?: { href: string };
   };


### PR DESCRIPTION
Added an optional boolean prop "shouldShowChangedFiles" to ManageVersion component. With the use of this flag consumer app can decide whether to show changed files columns in changes tab table or not.
![image](https://user-images.githubusercontent.com/97600048/220339470-eac3eb91-ca54-49e7-bcb4-416c2ecac838.png)
