### PR TITLE
Fix Tile height issue introduced by ThemeProvider

### DIFF
--- a/packages/modules/imodel-browser/src/components/gridStructure/GridStructure.scss
+++ b/packages/modules/imodel-browser/src/components/gridStructure/GridStructure.scss
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 @import "../../index.scss";
 $space-for-shadows: 3px;
 
@@ -15,4 +15,8 @@ $space-for-shadows: 3px;
   gap: $responsive-grid-gutter;
   overflow: hidden;
   padding: $space-for-shadows;
+
+  > * {
+    display: inline-flex;
+  }
 }


### PR DESCRIPTION
Addition of `ThemeProvider` around the `IModelTile` and `ITwinTile` components cause the tiles to have different height when the descriptions are different, this fixes it by expanding the grid content (`ThemeProviders`) to the full available height of the grid element.

Before: 
![image](https://github.com/iTwin/admin-components-react/assets/1904889/d976f48b-9784-40d0-be1b-1bc5a7e6b8f6)

After: 
![image](https://github.com/iTwin/admin-components-react/assets/1904889/4dd0d8af-a383-4316-b4f8-531eed2bdae6)
