### PR TITLE
Ability to limit iModel tiles

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/DanishM-limit_2023-08-30-09-47.json
+++ b/common/changes/@itwin/imodel-browser-react/DanishM-limit_2023-08-30-09-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Ability to limit iModel tiles",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -84,6 +84,8 @@ export interface IModelGridProps {
   searchText?: string;
   /**iModel view mode */
   viewMode?: IModelViewType;
+  /** Number of tiles to fetch, default is 100 */
+  pageSize?: number;
 }
 
 /**
@@ -103,6 +105,7 @@ export const IModelGrid = ({
   emptyStateComponent,
   searchText,
   viewMode,
+  pageSize,
 }: IModelGridProps) => {
   const [sort, setSort] = useState<IModelSortOptions | undefined>(sortOptions);
   const strings = _mergeStrings(
@@ -129,6 +132,7 @@ export const IModelGrid = ({
     iTwinId,
     sortOptions: sort,
     searchText,
+    pageSize,
   });
 
   const iModels = React.useMemo(

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -85,7 +85,7 @@ export interface IModelGridProps {
   /**iModel view mode */
   viewMode?: IModelViewType;
   /** Number of tiles to fetch, default is 100 */
-  pageSize?: number;
+  maxCount?: number;
 }
 
 /**
@@ -105,7 +105,7 @@ export const IModelGrid = ({
   emptyStateComponent,
   searchText,
   viewMode,
-  pageSize,
+  maxCount,
 }: IModelGridProps) => {
   const [sort, setSort] = useState<IModelSortOptions | undefined>(sortOptions);
   const strings = _mergeStrings(
@@ -132,7 +132,7 @@ export const IModelGrid = ({
     iTwinId,
     sortOptions: sort,
     searchText,
-    pageSize,
+    maxCount,
   });
 
   const iModels = React.useMemo(

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -84,7 +84,7 @@ export interface IModelGridProps {
   searchText?: string;
   /**iModel view mode */
   viewMode?: IModelViewType;
-  /** Number of tiles to fetch, default is 100 */
+  /** Maximum number of iModels to fetch, default is unlimited */
   maxCount?: number;
 }
 

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.test.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.test.ts
@@ -189,7 +189,7 @@ describe("useIModelData hook", () => {
     );
   });
 
-  it("should call correct api when pageSize is provided", async () => {
+  it("should call correct api when maxCount is provided", async () => {
     // Arrange
     const fetchSpy = jest.spyOn(window, "fetch");
 
@@ -198,7 +198,7 @@ describe("useIModelData hook", () => {
       useIModelData({
         iTwinId: "iTwinId",
         accessToken: "accessToken",
-        pageSize: 5,
+        maxCount: 5,
       })
     );
     await waitForNextUpdate();

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -19,6 +19,7 @@ export interface IModelDataHookOptions {
   sortOptions?: IModelSortOptions;
   apiOverrides?: ApiOverrides<IModelFull[]>;
   searchText?: string | undefined;
+  pageSize?: number;
 }
 const PAGE_SIZE = 100;
 
@@ -28,6 +29,7 @@ export const useIModelData = ({
   sortOptions,
   apiOverrides,
   searchText,
+  pageSize,
 }: IModelDataHookOptions) => {
   const sortType = sortOptions?.sortType === "name" ? "name" : undefined; //Only available sort by API at the moment.
   const sortDescending = sortOptions?.descending;
@@ -56,7 +58,14 @@ export const useIModelData = ({
     setIModels([]);
     setPage(0);
     setMorePages(true);
-  }, [accessToken, iTwinId, apiOverrides?.data, apiOverrides, searchText]);
+  }, [
+    accessToken,
+    iTwinId,
+    apiOverrides?.data,
+    apiOverrides,
+    searchText,
+    pageSize,
+  ]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const abortController = useMemo(() => new AbortController(), [searchText]);
@@ -85,7 +94,9 @@ export const useIModelData = ({
     const sorting = sortType
       ? `&$orderBy=${sortType} ${sortDescending ? "desc" : "asc"}`
       : "";
-    const paging = `&$skip=${page * PAGE_SIZE}&$top=${PAGE_SIZE}`;
+    const paging = `&$skip=${page * (pageSize ?? PAGE_SIZE)}&$top=${
+      pageSize ?? PAGE_SIZE
+    }`;
     const searching = searchText?.trim() ? `&name=${searchText}` : "";
 
     const url = `${_getAPIServer(
@@ -111,7 +122,10 @@ export const useIModelData = ({
       })
       .then((result: { iModels: IModelFull[] }) => {
         setStatus(DataStatus.Complete);
-        if (result.iModels.length !== PAGE_SIZE) {
+        if (
+          result.iModels.length !== PAGE_SIZE ||
+          result.iModels.length === pageSize
+        ) {
           setMorePages(false);
         }
         setIModels((imodels) =>
@@ -138,6 +152,7 @@ export const useIModelData = ({
     searchText,
     sortDescending,
     sortType,
+    pageSize,
   ]);
 
   useEffect(() => {

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -94,9 +94,14 @@ export const useIModelData = ({
     const sorting = sortType
       ? `&$orderBy=${sortType} ${sortDescending ? "desc" : "asc"}`
       : "";
-    const paging = `&$skip=${page * (maxCount ?? PAGE_SIZE)}&$top=${
-      maxCount ?? PAGE_SIZE
-    }`;
+    const skip = page * PAGE_SIZE;
+    let top;
+    if (maxCount) {
+      top = Math.min(PAGE_SIZE, maxCount - skip);
+    } else {
+      top = PAGE_SIZE;
+    }
+    const paging = `&$skip=${skip}&$top=${top}`;
     const searching = searchText?.trim() ? `&name=${searchText}` : "";
 
     const url = `${_getAPIServer(

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -19,7 +19,7 @@ export interface IModelDataHookOptions {
   sortOptions?: IModelSortOptions;
   apiOverrides?: ApiOverrides<IModelFull[]>;
   searchText?: string | undefined;
-  pageSize?: number;
+  maxCount?: number;
 }
 const PAGE_SIZE = 100;
 
@@ -29,7 +29,7 @@ export const useIModelData = ({
   sortOptions,
   apiOverrides,
   searchText,
-  pageSize,
+  maxCount,
 }: IModelDataHookOptions) => {
   const sortType = sortOptions?.sortType === "name" ? "name" : undefined; //Only available sort by API at the moment.
   const sortDescending = sortOptions?.descending;
@@ -64,7 +64,7 @@ export const useIModelData = ({
     apiOverrides?.data,
     apiOverrides,
     searchText,
-    pageSize,
+    maxCount,
   ]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -94,8 +94,8 @@ export const useIModelData = ({
     const sorting = sortType
       ? `&$orderBy=${sortType} ${sortDescending ? "desc" : "asc"}`
       : "";
-    const paging = `&$skip=${page * (pageSize ?? PAGE_SIZE)}&$top=${
-      pageSize ?? PAGE_SIZE
+    const paging = `&$skip=${page * (maxCount ?? PAGE_SIZE)}&$top=${
+      maxCount ?? PAGE_SIZE
     }`;
     const searching = searchText?.trim() ? `&name=${searchText}` : "";
 
@@ -124,7 +124,7 @@ export const useIModelData = ({
         setStatus(DataStatus.Complete);
         if (
           result.iModels.length !== PAGE_SIZE ||
-          result.iModels.length === pageSize
+          result.iModels.length === maxCount
         ) {
           setMorePages(false);
         }
@@ -152,7 +152,7 @@ export const useIModelData = ({
     searchText,
     sortDescending,
     sortType,
-    pageSize,
+    maxCount,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Added the ability to limit the page size of iModel tiles.
![image](https://github.com/iTwin/admin-components-react/assets/64415995/eb498b90-7faf-4be1-9999-64cbb82b838b)
