### PR TITLE
Adding Download action for named version.

### DIFF
--- a/common/changes/@itwin/manage-versions-react/sourabh-context-menu-update-for-manage-versions_2024-03-28-13-32.json
+++ b/common/changes/@itwin/manage-versions-react/sourabh-context-menu-update-for-manage-versions_2024-03-28-13-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "Adding Download action on Named version table to download the associated files of a Named Version from the UI. Hence, Added changeset checkpoint API to download file. Also, added context menu to provide quick access to multiple actions.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react"
+}

--- a/packages/modules/manage-versions/src/clients/changesetClient.test.ts
+++ b/packages/modules/manage-versions/src/clients/changesetClient.test.ts
@@ -58,4 +58,40 @@ describe("ChangesetClient", () => {
       }
     );
   });
+
+  it("should have the correct url and resolve with the checkpoint data on getChangesetCheckpoint", async () => {
+    const changesetIndex = 5;
+    const mockCheckpoint = {
+      changesetIndex: changesetIndex,
+      changesetId: "mockChangesetId",
+      state: "available",
+      containerAccessInfo: {
+        account: "mockAccount",
+        container: "mockContainer",
+        sas: "mockSasToken",
+        dbName: "mockDbName",
+      },
+      _links: {
+        download: {
+          href: "http://download-link",
+        },
+      },
+    };
+
+    mockHttpGet.mockResolvedValue({ checkpoint: mockCheckpoint });
+
+    const checkpoint = await changesetClient.getChangesetCheckpoint(
+      MOCKED_IMODEL_ID,
+      changesetIndex
+    );
+    expect(mockHttpGet).toHaveBeenCalledWith(
+      `https://api.bentley.com/imodels/${MOCKED_IMODEL_ID}/changesets/${changesetIndex}/checkpoint`,
+      {
+        headers: {
+          Accept: "application/vnd.bentley.itwin-platform.v2+json",
+        },
+      }
+    );
+    expect(checkpoint).toEqual(mockCheckpoint);
+  });
 });

--- a/packages/modules/manage-versions/src/clients/changesetClient.ts
+++ b/packages/modules/manage-versions/src/clients/changesetClient.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { LogFunc } from "../components/ManageVersions/types";
-import { Changeset, HttpHeaderNames, User } from "../models";
+import { Changeset, Checkpoint, HttpHeaderNames, User } from "../models";
 import { RequestOptions } from "../models/requestOptions";
 import { HttpClient } from "./httpClient";
 import { UrlBuilder } from "./urlBuilder";
@@ -54,5 +54,25 @@ export class ChangesetClient {
         }
       )
       .then((resp) => resp.users);
+  }
+
+  public async getChangesetCheckpoint(
+    imodelId: string,
+    changesetIndex: number,
+    requestOptions: RequestOptions = {}
+  ): Promise<Checkpoint> {
+    const url = `${UrlBuilder.buildChangesetUrl(
+      imodelId,
+      this._serverEnvironmentPrefix
+    )}/${changesetIndex}/checkpoint${UrlBuilder.getQuery(requestOptions)}`;
+
+    return this._http
+      .get(url, {
+        headers: {
+          [HttpHeaderNames.Accept]:
+            "application/vnd.bentley.itwin-platform.v2+json",
+        },
+      })
+      .then((resp) => resp.checkpoint);
   }
 }

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
@@ -81,7 +81,7 @@ describe("ManageVersions", () => {
       expect(cells[2].textContent).toContain(mockedVersion.createdBy);
       expect(cells[3].textContent).toContain(mockedVersion.createdDateTime);
       const actionsCell = cells[4] as HTMLElement;
-      const button = (actionsCell as HTMLElement).querySelector("button");
+      const button = within(actionsCell as HTMLElement).getByText("More");
       expect(button).toBeTruthy();
     });
     expect(mockGetVersions).toHaveBeenCalledWith(MOCKED_IMODEL_ID, {
@@ -258,12 +258,12 @@ describe("ManageVersions", () => {
       container.querySelector(".iui-progress-indicator-radial")
     );
     const versionRows = container.querySelectorAll(
-      ".iui-table-body .iui-table-row"
+      "div[role='rowgroup'] > div[role='row']"
     );
     const firstRowCells = versionRows[0].querySelectorAll("div[role='cell']");
     expect(firstRowCells.length).toBe(5);
     const actionsCell = firstRowCells[4] as HTMLElement;
-    const button = within(actionsCell as HTMLElement).getByTitle("More");
+    const button = within(actionsCell as HTMLElement).getByText("More");
     expect(button).toBeTruthy();
     button.click();
     const updateAction = screen.getByText(defaultStrings.updateNamedVersion);
@@ -304,7 +304,7 @@ describe("ManageVersions", () => {
       MockedVersion(0).createdDateTime
     );
     const actionButton = firstRowCells[4] as HTMLElement;
-    const updateButton = within(actionButton as HTMLElement).getByTitle("More");
+    const updateButton = within(actionButton as HTMLElement).getByText("More");
     expect(updateButton).toBeTruthy();
     expect(mockGetVersions).toHaveBeenCalledTimes(2);
     expect(mockUpdateVersion).toHaveBeenCalled();

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
@@ -80,9 +80,9 @@ describe("ManageVersions", () => {
 
       expect(cells[2].textContent).toContain(mockedVersion.createdBy);
       expect(cells[3].textContent).toContain(mockedVersion.createdDateTime);
-      within(cells[4] as HTMLElement).getByTitle(
-        defaultStrings.updateNamedVersion
-      );
+      const actionsCell = cells[4] as HTMLElement;
+      const button = (actionsCell as HTMLElement).querySelector("button");
+      expect(button).toBeTruthy();
     });
     expect(mockGetVersions).toHaveBeenCalledWith(MOCKED_IMODEL_ID, {
       top: 100,
@@ -257,12 +257,17 @@ describe("ManageVersions", () => {
     await waitForElementToBeRemoved(() =>
       container.querySelector(".iui-progress-indicator-radial")
     );
-
-    const updateVersionButtons = screen.getAllByTitle(
-      defaultStrings.updateNamedVersion
+    const versionRows = container.querySelectorAll(
+      ".iui-table-body .iui-table-row"
     );
-    expect(updateVersionButtons.length).toBe(3);
-    updateVersionButtons[0].click();
+    const firstRowCells = versionRows[0].querySelectorAll("div[role='cell']");
+    expect(firstRowCells.length).toBe(5);
+    const actionsCell = firstRowCells[4] as HTMLElement;
+    const button = within(actionsCell as HTMLElement).getByTitle("More");
+    expect(button).toBeTruthy();
+    button.click();
+    const updateAction = screen.getByText(defaultStrings.updateNamedVersion);
+    updateAction.click();
 
     await waitForSelectorToExist("input");
     const nameInput = document.querySelector("input") as HTMLInputElement;
@@ -298,9 +303,9 @@ describe("ManageVersions", () => {
     expect(versionCells[3].textContent).toEqual(
       MockedVersion(0).createdDateTime
     );
-    within(versionCells[4] as HTMLElement).getByTitle(
-      defaultStrings.updateNamedVersion
-    );
+    const actionButton = firstRowCells[4] as HTMLElement;
+    const updateButton = within(actionButton as HTMLElement).getByTitle("More");
+    expect(updateButton).toBeTruthy();
     expect(mockGetVersions).toHaveBeenCalledTimes(2);
     expect(mockUpdateVersion).toHaveBeenCalled();
   });

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -53,7 +53,7 @@ export const defaultStrings: ManageVersionsStringOverrides = {
   messageCouldNotCreateVersion:
     "Could not create a Named Version. Please try again later.",
   messageVersionUpdated: 'Named Version "{{name}}" was successfully updated.',
-  messageDownloadedFileSuccessfully: "File was successfully downloaded.",
+  messageFileDownloadInProgress: "File download in progress...",
   messageCouldNotDownloadedFileSuccessfully: "Unable to download file.",
   messageInsufficientPermissionsToUpdateVersion:
     "You do not have the required permissions to update a Named Version.",

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -53,7 +53,7 @@ export const defaultStrings: ManageVersionsStringOverrides = {
   messageCouldNotCreateVersion:
     "Could not create a Named Version. Please try again later.",
   messageVersionUpdated: 'Named Version "{{name}}" was successfully updated.',
-  messageFileDownloadInProgress: "File download in progress...",
+  messageFileDownloadInProgress: "Downloading file...",
   messageCouldNotDownloadedFileSuccessfully: "Unable to download file.",
   messageInsufficientPermissionsToUpdateVersion:
     "You do not have the required permissions to update a Named Version.",

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -38,6 +38,7 @@ export const defaultStrings: ManageVersionsStringOverrides = {
   updateNamedVersion: "Update a Named Version",
   update: "Update",
   download: "Download",
+  More: "More",
   view: "View",
   messageFailedGetNamedVersions:
     "Could not get Named Versions. Please try again later.",

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -37,6 +37,7 @@ export const defaultStrings: ManageVersionsStringOverrides = {
   create: "Create",
   updateNamedVersion: "Update a Named Version",
   update: "Update",
+  download: "Download",
   view: "View",
   messageFailedGetNamedVersions:
     "Could not get Named Versions. Please try again later.",
@@ -51,6 +52,8 @@ export const defaultStrings: ManageVersionsStringOverrides = {
   messageCouldNotCreateVersion:
     "Could not create a Named Version. Please try again later.",
   messageVersionUpdated: 'Named Version "{{name}}" was successfully updated.',
+  messageDownloadedFileSuccessfully: "File was successfully downloaded.",
+  messageCouldNotDownloadedFileSuccessfully: "Unable to download file.",
   messageInsufficientPermissionsToUpdateVersion:
     "You do not have the required permissions to update a Named Version.",
   messageCouldNotUpdateVersion:

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.test.tsx
@@ -54,10 +54,13 @@ describe("VersionsTab", () => {
       expect(cells[4].textContent).toContain(defaultStrings.view);
       const viewSpan = screen.getByText("View");
       fireEvent.click(viewSpan);
-
-      within(cells[5] as HTMLElement).getByTitle(
-        defaultStrings.updateNamedVersion
-      );
+      const actionButton = within(cells[5] as HTMLElement).getByTitle("More");
+      expect(actionButton).toBeTruthy();
+      fireEvent.click(actionButton);
+      const updateAction = screen.getByText(defaultStrings.updateNamedVersion);
+      const downloadAction = screen.getByText(defaultStrings.download);
+      expect(updateAction).toBeTruthy();
+      expect(downloadAction).toBeTruthy();
     });
     expect(onViewClick).toHaveBeenCalledTimes(1);
   });
@@ -125,11 +128,17 @@ describe("VersionsTab", () => {
         expect(cells[4].textContent).toContain(defaultStrings.view);
         const viewSpan = screen.getByText("View");
         fireEvent.click(viewSpan);
-        const updateNamedVersionButton = within(
-          cells[5] as HTMLElement
-        ).queryByTitle(defaultStrings.updateNamedVersion);
-
-        expect(updateNamedVersionButton).toBeTruthy();
+        const actionsCell = cells[cells.length - 1];
+        const actionButton = within(actionsCell as HTMLElement).getByTitle(
+          "More"
+        );
+        fireEvent.click(actionButton);
+        const updateAction = screen.getByText(
+          defaultStrings.updateNamedVersion
+        );
+        if (updateAction) {
+          expect(updateAction).toBeTruthy();
+        }
       } else {
         expect(cells[0].textContent).toContain(
           MockedChangeset(index).displayName
@@ -144,11 +153,8 @@ describe("VersionsTab", () => {
           MockedChangeset(index).pushDateTime
         );
         expect(cells[4].textContent).not.toContain(defaultStrings.view);
-        const updateNamedVersionButton = within(
-          cells[5] as HTMLElement
-        ).queryByTitle(defaultStrings.updateNamedVersion);
-
-        expect(updateNamedVersionButton).toBeFalsy();
+        const actionsCell = cells[cells.length - 1];
+        expect(actionsCell.children.length).toBe(0);
       }
     });
   });

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.test.tsx
@@ -54,13 +54,15 @@ describe("VersionsTab", () => {
       expect(cells[4].textContent).toContain(defaultStrings.view);
       const viewSpan = screen.getByText("View");
       fireEvent.click(viewSpan);
-      const actionButton = within(cells[5] as HTMLElement).getByTitle("More");
+      const actionButton = within(cells[5] as HTMLElement).getByText("More");
       expect(actionButton).toBeTruthy();
       fireEvent.click(actionButton);
       const updateAction = screen.getByText(defaultStrings.updateNamedVersion);
-      const downloadAction = screen.getByText(defaultStrings.download);
+      if (defaultStrings.download) {
+        const downloadAction = screen.getByText(defaultStrings.download);
+        expect(downloadAction).toBeTruthy();
+      }
       expect(updateAction).toBeTruthy();
-      expect(downloadAction).toBeTruthy();
     });
     expect(onViewClick).toHaveBeenCalledTimes(1);
   });
@@ -129,7 +131,7 @@ describe("VersionsTab", () => {
         const viewSpan = screen.getByText("View");
         fireEvent.click(viewSpan);
         const actionsCell = cells[cells.length - 1];
-        const actionButton = within(actionsCell as HTMLElement).getByTitle(
+        const actionButton = within(actionsCell as HTMLElement).getByText(
           "More"
         );
         fireEvent.click(actionButton);

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
@@ -6,7 +6,7 @@ import "./VersionsTab.scss";
 
 import { SvgDownload, SvgEdit } from "@itwin/itwinui-icons-react";
 import { Table, Text, toaster } from "@itwin/itwinui-react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { CellProps } from "react-table";
 
 import { ChangesetClient } from "../../../clients/changesetClient";
@@ -67,18 +67,6 @@ const VersionsTab = (props: VersionsTabProps) => {
     }
   }
 
-  const [openMenuId, setOpenMenuId] = useState(null);
-
-  const toggleContextMenu = useCallback((rowId) => {
-    setOpenMenuId((currentOpenMenuId) =>
-      currentOpenMenuId === rowId ? null : rowId
-    );
-  }, []);
-
-  const closeContextMenu = () => {
-    setOpenMenuId(null);
-  };
-
   const onDownloadClick = useCallback(
     async (changesetIndex: number) => {
       toaster.closeAll();
@@ -88,7 +76,7 @@ const VersionsTab = (props: VersionsTabProps) => {
           changesetIndex
         );
         const downloadUrl = checkpointInfo._links.download.href;
-        window.open(downloadUrl, "_blank");
+        window.open(downloadUrl, "_blank", "noopener,noreferrer");
         toaster.positive(stringsOverrides.messageDownloadedFileSuccessfully, {
           hasCloseButton: true,
         });
@@ -99,7 +87,6 @@ const VersionsTab = (props: VersionsTabProps) => {
             hasCloseButton: true,
           }
         );
-        console.error("Download failed:", error);
       }
     },
     [
@@ -170,8 +157,8 @@ const VersionsTab = (props: VersionsTabProps) => {
           },
         },
         {
-          title: stringsOverrides.download,
-          label: stringsOverrides.download,
+          title: stringsOverrides.download ?? "Download",
+          label: stringsOverrides.download ?? "Download",
           icon: <SvgDownload />,
           disabled: false,
           onClick: async () => {
@@ -248,13 +235,7 @@ const VersionsTab = (props: VersionsTabProps) => {
               return (
                 <>
                   {isNamedVersion(props.row.original) ? (
-                    <ContextMenu
-                      menuActions={getToolbarActions(props)}
-                      isMenuOpen={openMenuId === props.row.original.version.id}
-                      toggleMenu={toggleContextMenu}
-                      rowId={props.row.original.version.id}
-                      onClose={closeContextMenu}
-                    />
+                    <ContextMenu menuActions={getToolbarActions(props)} />
                   ) : (
                     <></>
                   )}
@@ -293,8 +274,6 @@ const VersionsTab = (props: VersionsTabProps) => {
     onViewClick,
     generateCellContent,
     getToolbarActions,
-    openMenuId,
-    toggleContextMenu,
   ]);
 
   const emptyTableContent = React.useMemo(() => {

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
@@ -77,7 +77,7 @@ const VersionsTab = (props: VersionsTabProps) => {
         );
         const downloadUrl = checkpointInfo._links.download.href;
         window.open(downloadUrl, "_blank", "noopener,noreferrer");
-        toaster.positive(stringsOverrides.messageDownloadedFileSuccessfully, {
+        toaster.informational(stringsOverrides.messageFileDownloadInProgress, {
           hasCloseButton: true,
         });
       } catch (error) {
@@ -93,7 +93,7 @@ const VersionsTab = (props: VersionsTabProps) => {
       changesetClient,
       imodelId,
       stringsOverrides.messageCouldNotDownloadedFileSuccessfully,
-      stringsOverrides.messageDownloadedFileSuccessfully,
+      stringsOverrides.messageFileDownloadInProgress,
     ]
   );
 

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
@@ -79,6 +79,7 @@ const VersionsTab = (props: VersionsTabProps) => {
         window.open(downloadUrl, "_blank", "noopener,noreferrer");
         toaster.informational(stringsOverrides.messageFileDownloadInProgress, {
           hasCloseButton: true,
+          duration: 2000,
         });
       } catch (error) {
         toaster.negative(

--- a/packages/modules/manage-versions/src/components/ManageVersions/types.ts
+++ b/packages/modules/manage-versions/src/components/ManageVersions/types.ts
@@ -33,7 +33,9 @@ export type ManageVersionsStringOverrides = {
   /** Default: `Update` */
   update: string;
   /** Default: `Download` */
-  download: string;
+  download?: string;
+  /** Label for Named Version context menu` Default `More` */
+  More?: string;
   /** Default: `View` */
   view: string;
   /** Error message when failed to fetch Named Versions. Default `Could not get Named Versions. Please try again later.`. */

--- a/packages/modules/manage-versions/src/components/ManageVersions/types.ts
+++ b/packages/modules/manage-versions/src/components/ManageVersions/types.ts
@@ -56,7 +56,7 @@ export type ManageVersionsStringOverrides = {
   messageCouldNotCreateVersion: string;
   /** Default `Named Version "{{name}}" was successfully updated.` - `{{name}}` - Named Version name */
   messageVersionUpdated: string;
-  /** Default `File was successfully downloaded.`. */
+  /** Default `Downloading file...`. */
   messageFileDownloadInProgress?: string;
   /** Default `Unable to download file.`. */
   messageCouldNotDownloadedFileSuccessfully?: string;

--- a/packages/modules/manage-versions/src/components/ManageVersions/types.ts
+++ b/packages/modules/manage-versions/src/components/ManageVersions/types.ts
@@ -32,6 +32,8 @@ export type ManageVersionsStringOverrides = {
   updateNamedVersion: string;
   /** Default: `Update` */
   update: string;
+  /** Default: `Download` */
+  download: string;
   /** Default: `View` */
   view: string;
   /** Error message when failed to fetch Named Versions. Default `Could not get Named Versions. Please try again later.`. */
@@ -52,6 +54,10 @@ export type ManageVersionsStringOverrides = {
   messageCouldNotCreateVersion: string;
   /** Default `Named Version "{{name}}" was successfully updated.` - `{{name}}` - Named Version name */
   messageVersionUpdated: string;
+  /** Default `File was successfully downloaded.`. */
+  messageDownloadedFileSuccessfully: string;
+  /** Default `Unable to download file.`. */
+  messageCouldNotDownloadedFileSuccessfully: string;
   /** Default `You do not have the required permissions to update a Named Version.` */
   messageInsufficientPermissionsToUpdateVersion: string;
   /** Default `Could not update a Named Version. Please try again later.` */

--- a/packages/modules/manage-versions/src/components/ManageVersions/types.ts
+++ b/packages/modules/manage-versions/src/components/ManageVersions/types.ts
@@ -57,9 +57,9 @@ export type ManageVersionsStringOverrides = {
   /** Default `Named Version "{{name}}" was successfully updated.` - `{{name}}` - Named Version name */
   messageVersionUpdated: string;
   /** Default `File was successfully downloaded.`. */
-  messageDownloadedFileSuccessfully: string;
+  messageFileDownloadInProgress?: string;
   /** Default `Unable to download file.`. */
-  messageCouldNotDownloadedFileSuccessfully: string;
+  messageCouldNotDownloadedFileSuccessfully?: string;
   /** Default `You do not have the required permissions to update a Named Version.` */
   messageInsufficientPermissionsToUpdateVersion: string;
   /** Default `Could not update a Named Version. Please try again later.` */

--- a/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.test.tsx
+++ b/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.test.tsx
@@ -6,11 +6,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
+import { ConfigProvider } from "../../common/configContext";
+import { MOCKED_CONFIG_PROPS } from "../../mocks";
 import { ContextMenu, ContextMenuProps } from "./ContextMenu";
 
 describe("ContextMenu", () => {
-  const mockToggleMenu = jest.fn();
-  const mockOnClose = jest.fn();
   const mockActionClick = jest.fn();
 
   const defaultProps: ContextMenuProps = {
@@ -22,10 +22,6 @@ describe("ContextMenu", () => {
         label: "Perform Action 1",
       },
     ],
-    isMenuOpen: false,
-    toggleMenu: mockToggleMenu,
-    rowId: "row1",
-    onClose: mockOnClose,
   };
 
   beforeEach(() => {
@@ -33,24 +29,13 @@ describe("ContextMenu", () => {
   });
 
   it("should render with provided menu actions", () => {
-    render(<ContextMenu {...defaultProps} />);
-    fireEvent.click(screen.getByTitle("More"));
+    render(
+      <ConfigProvider {...MOCKED_CONFIG_PROPS}>
+        <ContextMenu {...defaultProps} />
+      </ConfigProvider>
+    );
+    fireEvent.click(screen.getByText("More"));
     expect(screen.queryByText("Perform Action 1")).not.toBeNull();
-  });
-
-  it("should toggle menu visibility on button click", () => {
-    render(<ContextMenu {...defaultProps} />);
-    const button = screen.getByTitle("More");
-    fireEvent.click(button);
-    expect(mockToggleMenu).toHaveBeenCalledWith("row1");
-  });
-
-  it("should call action onClick and closes menu when a menu item is clicked", () => {
-    render(<ContextMenu {...{ ...defaultProps, isMenuOpen: true }} />);
-    const menuItem = screen.getByTitle("Action 1");
-    fireEvent.click(menuItem);
-    expect(mockActionClick).toHaveBeenCalledTimes(1);
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it("does not trigger onClick for disabled menu actions", () => {
@@ -63,8 +48,12 @@ describe("ContextMenu", () => {
         },
       ],
     };
-    render(<ContextMenu {...disabledActionProps} />);
-    fireEvent.click(screen.getByTitle("More"));
+    render(
+      <ConfigProvider {...MOCKED_CONFIG_PROPS}>
+        <ContextMenu {...disabledActionProps} />
+      </ConfigProvider>
+    );
+    fireEvent.click(screen.getByText("More"));
     const menuItem = screen.getByTitle("Action 1");
     fireEvent.click(menuItem);
     expect(mockActionClick).not.toHaveBeenCalled();

--- a/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.test.tsx
+++ b/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.test.tsx
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import { ContextMenu, ContextMenuProps } from "./ContextMenu";
+
+describe("ContextMenu", () => {
+  const mockToggleMenu = jest.fn();
+  const mockOnClose = jest.fn();
+  const mockActionClick = jest.fn();
+
+  const defaultProps: ContextMenuProps = {
+    menuActions: [
+      {
+        icon: <svg></svg>,
+        onClick: mockActionClick,
+        title: "Action 1",
+        label: "Perform Action 1",
+      },
+    ],
+    isMenuOpen: false,
+    toggleMenu: mockToggleMenu,
+    rowId: "row1",
+    onClose: mockOnClose,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render with provided menu actions", () => {
+    render(<ContextMenu {...defaultProps} />);
+    fireEvent.click(screen.getByTitle("More"));
+    expect(screen.queryByText("Perform Action 1")).not.toBeNull();
+  });
+
+  it("should toggle menu visibility on button click", () => {
+    render(<ContextMenu {...defaultProps} />);
+    const button = screen.getByTitle("More");
+    fireEvent.click(button);
+    expect(mockToggleMenu).toHaveBeenCalledWith("row1");
+  });
+
+  it("should call action onClick and closes menu when a menu item is clicked", () => {
+    render(<ContextMenu {...{ ...defaultProps, isMenuOpen: true }} />);
+    const menuItem = screen.getByTitle("Action 1");
+    fireEvent.click(menuItem);
+    expect(mockActionClick).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger onClick for disabled menu actions", () => {
+    const disabledActionProps = {
+      ...defaultProps,
+      menuActions: [
+        {
+          ...defaultProps.menuActions[0],
+          disabled: true,
+        },
+      ],
+    };
+    render(<ContextMenu {...disabledActionProps} />);
+    fireEvent.click(screen.getByTitle("More"));
+    const menuItem = screen.getByTitle("Action 1");
+    fireEvent.click(menuItem);
+    expect(mockActionClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.tsx
+++ b/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.tsx
@@ -5,7 +5,9 @@
 
 import { SvgMore } from "@itwin/itwinui-icons-react";
 import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
-import React from "react";
+import React, { useCallback } from "react";
+
+import { useConfig } from "../../common/configContext";
 
 export type MenuAction = {
   icon?: JSX.Element;
@@ -17,47 +19,39 @@ export type MenuAction = {
 
 export interface ContextMenuProps {
   menuActions: MenuAction[];
-  isMenuOpen: boolean;
-  toggleMenu: (rowId: string) => void;
-  rowId: string;
-  onClose: () => void;
 }
 
-export const ContextMenu = ({
-  menuActions,
-  isMenuOpen,
-  toggleMenu,
-  rowId,
-  onClose,
-}: ContextMenuProps) => {
+export const ContextMenu = ({ menuActions }: ContextMenuProps) => {
+  const { stringsOverrides } = useConfig();
+
+  const menuItems = useCallback(
+    (close: () => void) => {
+      return menuActions.map((action, index) => (
+        <MenuItem
+          icon={action.icon}
+          key={index}
+          onClick={() => {
+            close();
+            action.onClick();
+          }}
+          title={action.title}
+          disabled={action.disabled}
+        >
+          {action.label}
+        </MenuItem>
+      ));
+    },
+    [menuActions]
+  );
+
   return (
-    <DropdownMenu
-      onClickOutside={onClose}
-      menuItems={() =>
-        menuActions.map((action, index) => (
-          <MenuItem
-            {...action}
-            key={index}
-            onClick={() => {
-              onClose();
-              action.onClick();
-            }}
-            title={action.title}
-            disabled={action.disabled}
-          >
-            {action.label}
-          </MenuItem>
-        ))
-      }
-      className="bnt-named-version-context-menu"
-      visible={isMenuOpen}
-    >
+    <DropdownMenu menuItems={menuItems}>
       <IconButton
-        onClick={() => toggleMenu(rowId)}
+        onClick={(e) => e.stopPropagation()}
         styleType="borderless"
         size="small"
         role="button"
-        title="More"
+        label={stringsOverrides.More}
       >
         <SvgMore />
       </IconButton>

--- a/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.tsx
+++ b/packages/modules/manage-versions/src/components/contextMenu/ContextMenu.tsx
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SvgMore } from "@itwin/itwinui-icons-react";
+import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
+import React from "react";
+
+export type MenuAction = {
+  icon?: JSX.Element;
+  onClick: () => void;
+  title: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export interface ContextMenuProps {
+  menuActions: MenuAction[];
+  isMenuOpen: boolean;
+  toggleMenu: (rowId: string) => void;
+  rowId: string;
+  onClose: () => void;
+}
+
+export const ContextMenu = ({
+  menuActions,
+  isMenuOpen,
+  toggleMenu,
+  rowId,
+  onClose,
+}: ContextMenuProps) => {
+  return (
+    <DropdownMenu
+      onClickOutside={onClose}
+      menuItems={() =>
+        menuActions.map((action, index) => (
+          <MenuItem
+            {...action}
+            key={index}
+            onClick={() => {
+              onClose();
+              action.onClick();
+            }}
+            title={action.title}
+            disabled={action.disabled}
+          >
+            {action.label}
+          </MenuItem>
+        ))
+      }
+      className="bnt-named-version-context-menu"
+      visible={isMenuOpen}
+    >
+      <IconButton
+        onClick={() => toggleMenu(rowId)}
+        styleType="borderless"
+        size="small"
+        role="button"
+        title="More"
+      >
+        <SvgMore />
+      </IconButton>
+    </DropdownMenu>
+  );
+};

--- a/packages/modules/manage-versions/src/models/checkpoint.ts
+++ b/packages/modules/manage-versions/src/models/checkpoint.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface Checkpoint {
+  changesetIndex: number;
+  changesetId: string;
+  state: string;
+  containerAccessInfo: ContainerAccessInfo;
+  _links: {
+    download: DownloadLink;
+  };
+}
+
+export interface ContainerAccessInfo {
+  account: string;
+  container: string;
+  sas: string;
+  dbName: string;
+}
+
+export interface DownloadLink {
+  href: string;
+}

--- a/packages/modules/manage-versions/src/models/index.ts
+++ b/packages/modules/manage-versions/src/models/index.ts
@@ -7,3 +7,4 @@ export * from "./changeset";
 export * from "./namedVersion";
 export * from "./user";
 export * from "./utils";
+export * from "./checkpoint";


### PR DESCRIPTION
**Changes: -**

_**Added**_

- **Download Named Version**: Users can now directly download the associated files of a Named Version from the UI. This enhancement simplifies the process of obtaining version-specific data, improving the user workflow. Simply click on the new download icon next to the version you wish to download.

- **Context Menu in Named Versions**: A context menu has been introduced to provide quick access to multiple actions for each Named Version. This new feature allows users to perform actions such as updating version details, downloading version data, and more, in a single, convenient location.

- **Checkpoint API Method**:  Added a new `getChangesetCheckpoint` method that downloads `.bim` files for named version that has changes up to a certain Changeset. For more information can visit  https://qa-developer.bentley.com/apis/imodels-v2/operations/get-changeset-checkpoint/

**_Improvements_**

- Enhanced the user interface by integrating a context menu to consolidate actions and provide a cleaner, more intuitive navigation experience.

**_Note_**

- This updates were made to include a download feature in the context menu of the Named Version Table, supporting our integration with iTwinHub. This improvement is synchronized with the rollout of the new iModel browser and version management tools within iTwinHub, intended to replace the current iModel management service of the Connect Portal which is using old sevices. 

- Hence, with these changes, we can smoothly transition from the old service of Connect's portal iModel manager to the new service.

_**Screen shot : -**_

**Before : -**

![image](https://github.com/iTwin/admin-components-react/assets/97873094/4d6889f4-ec94-4693-a1d7-31d7edf2ec8c)

**After : -**

![image](https://github.com/iTwin/admin-components-react/assets/97873094/9ab23864-08b5-4821-8f3d-cca49ab94e6e)

![image](https://github.com/iTwin/admin-components-react/assets/97873094/3ed6545a-5e2a-4bdf-9f61-1b2204a0104c)

