### PR TITLE
Adding search parameter for imodel-browser-react

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/sourabh-adding-search-parameter-for-imodel-browser_2024-06-04-07-50.json
+++ b/common/changes/@itwin/imodel-browser-react/sourabh-adding-search-parameter-for-imodel-browser_2024-06-04-07-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Adding `Search` parameter to get iModels instead of `Name`. `Search` allows user to search without need to put the exact iModel name.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/package.json
+++ b/packages/modules/imodel-browser/package.json
@@ -2,7 +2,7 @@
   "name": "@itwin/imodel-browser-react",
   "description": "Components that let the user browse the iModels of a context and select one.",
   "repository": "https://github.com/iTwin/admin-components-react/tree/main/packages/modules/imodel-browser",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -102,7 +102,7 @@ export const useIModelData = ({
       top = PAGE_SIZE;
     }
     const paging = `&$skip=${skip}&$top=${top}`;
-    const searching = searchText?.trim() ? `&name=${searchText}` : "";
+    const searching = searchText?.trim() ? `&$search=${searchText}` : "";
 
     const url = `${_getAPIServer(
       apiOverrides


### PR DESCRIPTION
"Adding **`Search`** parameter to get iModels instead of **`Name`**. **`Search`** allows user to search without need to put the exact iModel name." 

- User can search iModels without need to put the exact name.
- Allow users to filter iModels whose name or description property contains the search string.

Changes : -

- useIModelData.ts -  Changed the parameter from "name" to "$search".


Work Item : -

[Product Backlog Item 1447138](https://dev.azure.com/bentleycs/beconnect/_workitems/edit/1447138): Modify iModel Browser to support substring search ability