### PR TITLE
Access token can be a function

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/john-access-token-prop_2024-09-13-17-50.json
+++ b/common/changes/@itwin/imodel-browser-react/john-access-token-prop_2024-09-13-17-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "ITwinGrid and IModelGrid 'accessToken' prop accepts a function so the token can renew.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -167,7 +167,7 @@ const useIndividualState = (iModel: IModelFull, props: IModelTileProps) => {
         }api.bentley.com/imodels/${iModel.id}/namedversions`,
         {
           headers: {
-            Authorization: props.accessToken ?? "",
+            Authorization: (props.accessToken as string) ?? "",
             Prefer: "return=minimal",
             Accept: "application/vnd.bentley.itwin-platform.v2+json",
           },

--- a/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
@@ -182,7 +182,7 @@ const useIndividualState: IndividualITwinStateHook = (iTwin, props) => {
         // Start the fetch
         const response = await fetch(url, {
           headers: {
-            Authorization: props.gridProps.accessToken ?? "",
+            Authorization: (props.gridProps.accessToken as string) ?? "",
             Prefer: "return=minimal",
           },
         });

--- a/packages/apps/storybook/src/utils/storyHelp.ts
+++ b/packages/apps/storybook/src/utils/storyHelp.ts
@@ -14,7 +14,7 @@ export const accessTokenArgTypes = {
 
 /** HOC that will override the "accessToken" prop with the Addon token */
 export const withAccessTokenOverride: <
-  T extends { accessToken?: string | undefined }
+  T extends { accessToken?: string | (() => Promise<string>) }
 >(
   story: Story<T>
 ) => Story<T> = (Story) => (args, context) =>

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -33,8 +33,8 @@ export type IndividualITwinStateHook = (
 ) => Partial<ITwinTileProps>;
 
 export interface ITwinGridProps {
-  /** Access token that requires the `itwins:read` scope. */
-  accessToken?: string | undefined;
+  /** Access token that requires the `itwins:read` scope. Provide a function that returns the token to prevent the token from expiring. */
+  accessToken?: string | (() => Promise<string>) | undefined;
   /** Type of iTwin to request */
   requestType?: "favorites" | "recents" | "";
   /** Sub class of iTwin, defaults to Project */

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -25,8 +25,8 @@ import { useIModelData } from "./useIModelData";
 import { useIModelTableConfig } from "./useIModelTableConfig";
 export interface IModelGridProps {
   /**
-   * Access token that requires the `imodels:read` scope. */
-  accessToken?: string | undefined;
+   * Access token that requires the `imodels:read` scope. Provide a function that returns the token to prevent the token from expiring. */
+  accessToken?: string | (() => Promise<string>) | undefined;
   /** ITwin Id to list the iModels from (mutually exclusive to assetId) */
   iTwinId?: string | undefined;
   /** Thumbnail click handler. */

--- a/packages/modules/imodel-browser/src/containers/iModelThumbnail/IModelThumbnail.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelThumbnail/IModelThumbnail.tsx
@@ -19,7 +19,7 @@ export interface IModelThumbnailProps {
   /** Triggered on the image click, controls pointer */
   onClick?(iModelId: string): void;
   /* Access token that requires the `imodels:read` scope. */
-  accessToken?: string;
+  accessToken?: string | (() => Promise<string>) | undefined;
   /** Object that configures different overrides for the API
    * @property data thumbnail URL
    * @property serverEnvironmentPrefix Either qa or dev

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -18,7 +18,7 @@ export interface IModelTileProps {
   /** iModel to display */
   iModel: IModelFull;
   /** Access token to display */
-  accessToken?: string;
+  accessToken?: string | (() => Promise<string>) | undefined;
   /** List of options to build for the imodel context menu */
   iModelOptions?: ContextMenuBuilderItem<IModelFull>[];
   /** Function to call on thumbnail click */


### PR DESCRIPTION
Closes AB#1518319
Closes https://github.com/iTwin/admin-components-react/issues/124

### Changes

ITwinGrid and IModelGrid take a constant `accessToken` string as a prop. But the `accessToken` will eventually expire. So it would be better to accept a function `() => Promise<string>` as a prop, so that whenever the access token is used, it can be checked for expiry and renewed.

### Tests

Works in Storybook and manually tested with an app I have, looks okay to me.

Note: I couldn't get storybook working at first... it was because the scopes for new OIDC clients have changed to `itwin-platform`. Let me know if you want me to make that change in `.storybook/preview.js`