### PR TITLE
Refactor IModelGrid component to handle sort options dynamically

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/fix-imodel-sorting_2024-10-18-19-49.json
+++ b/common/changes/@itwin/imodel-browser-react/fix-imodel-sorting_2024-10-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix sorting in iModel grid",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -229,7 +229,6 @@ export const IModelGrid = ({
               onSort={(state) => {
                 const sortBy =
                   state.sortBy.length > 0 ? state.sortBy[0] : undefined;
-                debugger;
                 setIsSortOnTable(sortBy?.id !== undefined);
                 if (
                   !sortBy ||

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -109,12 +109,6 @@ export const IModelGrid = ({
   viewMode,
   maxCount,
 }: IModelGridProps) => {
-  const [sort, setSort] = useState<IModelSortOptions>(sortOptions);
-
-  useEffect(() => {
-    setSort({ sortType: "name", descending: sortOptions.descending });
-  }, [sortOptions.descending]);
-
   const strings = _mergeStrings(
     {
       tableColumnName: "Name",
@@ -139,7 +133,7 @@ export const IModelGrid = ({
     accessToken,
     apiOverrides,
     iTwinId,
-    sortOptions: sort,
+    sortOptions,
     searchText,
     maxCount,
   });
@@ -219,9 +213,6 @@ export const IModelGrid = ({
               }
               isLoading={fetchStatus === DataStatus.Fetching}
               isSortable
-              onSort={() =>
-                setSort({ sortType: "name", descending: !sort.descending })
-              }
               onBottomReached={fetchMore}
               className="iac-list-structure"
               autoResetFilters={false}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -109,6 +109,15 @@ export const IModelGrid = ({
   viewMode,
   maxCount,
 }: IModelGridProps) => {
+  const [sort, setSort] = React.useState<IModelSortOptions>(sortOptions);
+  const [isSortOnTable, setIsSortOnTable] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isSortOnTable) {
+      setSort({ sortType: "name", descending: sortOptions.descending });
+    }
+  }, [isSortOnTable, sortOptions.descending]);
+
   const strings = _mergeStrings(
     {
       tableColumnName: "Name",
@@ -133,7 +142,7 @@ export const IModelGrid = ({
     accessToken,
     apiOverrides,
     iTwinId,
-    sortOptions,
+    sortOptions: sort,
     searchText,
     maxCount,
   });
@@ -213,6 +222,15 @@ export const IModelGrid = ({
               }
               isLoading={fetchStatus === DataStatus.Fetching}
               isSortable
+              onSort={(state) => {
+                const columnSort = state.sortBy.find((s) => s.id === "name");
+                setIsSortOnTable(columnSort?.desc !== undefined);
+                setSort({
+                  sortType: "name",
+                  descending: columnSort?.desc ?? sortOptions.descending,
+                });
+              }}
+              manualSortBy
               onBottomReached={fetchMore}
               className="iac-list-structure"
               autoResetFilters={false}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -5,7 +5,7 @@
 import "./IModelGrid.scss";
 
 import { Table, ThemeProvider } from "@itwin/itwinui-react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { InView } from "react-intersection-observer";
 
 import { GridStructure } from "../../components/gridStructure/GridStructure";
@@ -109,7 +109,12 @@ export const IModelGrid = ({
   viewMode,
   maxCount,
 }: IModelGridProps) => {
-  const [sort, setSort] = useState<IModelSortOptions | undefined>(sortOptions);
+  const [sort, setSort] = useState<IModelSortOptions>(sortOptions);
+
+  useEffect(() => {
+    setSort({ sortType: "name", descending: sortOptions.descending });
+  }, [sortOptions.descending]);
+
   const strings = _mergeStrings(
     {
       tableColumnName: "Name",
@@ -122,7 +127,7 @@ export const IModelGrid = ({
       noIModels: "There are no iModels in this iTwin.",
       noContext: "No context provided",
       noAuthentication: "No access token provided",
-      error: "An error occured",
+      error: "An error occurred",
     },
     stringsOverrides
   );
@@ -215,7 +220,7 @@ export const IModelGrid = ({
               isLoading={fetchStatus === DataStatus.Fetching}
               isSortable
               onSort={() =>
-                setSort({ sortType: "name", descending: !sort?.descending })
+                setSort({ sortType: "name", descending: !sort.descending })
               }
               onBottomReached={fetchMore}
               className="iac-list-structure"

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -114,12 +114,20 @@ export const IModelGrid = ({
 
   React.useEffect(() => {
     if (!isSortOnTable) {
-      setSort({
-        sortType: sortOptions.sortType,
-        descending: sortOptions.descending,
-      });
+      const defaultTableSort: IModelSortOptions = {
+        sortType: "name",
+        descending: false,
+      };
+      setSort(
+        viewMode === "cells"
+          ? defaultTableSort
+          : {
+              sortType: sortOptions.sortType,
+              descending: sortOptions.descending,
+            }
+      );
     }
-  }, [isSortOnTable, sortOptions.descending, sortOptions.sortType]);
+  }, [isSortOnTable, sortOptions.descending, sortOptions.sortType, viewMode]);
 
   const strings = _mergeStrings(
     {

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -5,7 +5,7 @@
 import "./IModelGrid.scss";
 
 import { Table, ThemeProvider } from "@itwin/itwinui-react";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { InView } from "react-intersection-observer";
 
 import { GridStructure } from "../../components/gridStructure/GridStructure";

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -114,9 +114,12 @@ export const IModelGrid = ({
 
   React.useEffect(() => {
     if (!isSortOnTable) {
-      setSort({ sortType: "name", descending: sortOptions.descending });
+      setSort({
+        sortType: sortOptions.sortType,
+        descending: sortOptions.descending,
+      });
     }
-  }, [isSortOnTable, sortOptions.descending]);
+  }, [isSortOnTable, sortOptions.descending, sortOptions.sortType]);
 
   const strings = _mergeStrings(
     {
@@ -224,11 +227,20 @@ export const IModelGrid = ({
               isLoading={fetchStatus === DataStatus.Fetching}
               isSortable
               onSort={(state) => {
-                const columnSort = state.sortBy.find((s) => s.id === "name");
-                setIsSortOnTable(columnSort?.desc !== undefined);
+                const sortBy =
+                  state.sortBy.length > 0 ? state.sortBy[0] : undefined;
+                debugger;
+                setIsSortOnTable(sortBy?.id !== undefined);
+                if (
+                  !sortBy ||
+                  sortBy.desc === undefined ||
+                  (sortBy.id !== "name" && sortBy.id !== "createdDateTime")
+                ) {
+                  return;
+                }
                 setSort({
-                  sortType: "name",
-                  descending: columnSort?.desc ?? sortOptions.descending,
+                  sortType: sortBy.id,
+                  descending: sortBy.desc,
                 });
               }}
               manualSortBy

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -34,7 +34,10 @@ export const useIModelData = ({
   maxCount,
   viewMode,
 }: IModelDataHookOptions) => {
-  const sortType = sortOptions?.sortType === "name" ? "name" : undefined; //Only available sort by API at the moment.
+  const sortType =
+    sortOptions && ["name", "createdDateTime"].includes(sortOptions.sortType)
+      ? sortOptions.sortType
+      : undefined; //Only available sort by API at the moment.
   const sortDescending = sortOptions?.descending;
   const [iModels, setIModels] = React.useState<IModelFull[]>([]);
   const sortedIModels = useIModelSort(iModels, sortOptions);

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelSort.test.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelSort.test.ts
@@ -8,11 +8,12 @@ import { IModelFull, IModelSortOptionsKeys } from "../../types";
 import { useIModelSort } from "./useIModelSort";
 
 describe("useIModelSort hook", () => {
-  it.each(["name"] as IModelSortOptionsKeys[])(
+  it.each(["name", "createdDateTime"] as IModelSortOptionsKeys[])(
     "sorts correctly with %s",
     (sortType) => {
       const expectedSortOrder = {
         name: ["3", "4", "1", "2", "5"],
+        createdDateTime: ["4", "5", "2", "3", "1"],
       }[sortType];
       const iModels: IModelFull[] = [
         {

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -68,7 +68,7 @@ export const useIModelTableConfig = ({
             disableSortBy: true,
           },
           {
-            id: "LastModified",
+            id: "createdDateTime",
             Header: strings.tableColumnLastModified,
             accessor: "createdDateTime",
             maxWidth: 350,

--- a/packages/modules/imodel-browser/src/types.ts
+++ b/packages/modules/imodel-browser/src/types.ts
@@ -72,7 +72,7 @@ export enum DataStatus {
 type SortOptions<T, K extends keyof T> = { sortType: K; descending: boolean };
 
 /** Supported IModel sorting types */
-export type IModelSortOptionsKeys = "name";
+export type IModelSortOptionsKeys = "name" | "createdDateTime";
 
 /** Object/function that configure IModel sorting behavior. */
 export type IModelSortOptions = SortOptions<IModelFull, IModelSortOptionsKeys>;


### PR DESCRIPTION
When providing a sortOptions and changing the descending option from true to false, the iModels in the grid or list do not get sorted accordingly.
Before Fix
![before-sort-fix](https://github.com/user-attachments/assets/8a66754b-43db-4550-968b-321569485d67)
After Fix
![after-sort-fix](https://github.com/user-attachments/assets/b7907f9a-4fd7-4d42-9805-217673fea7b6)
