### PR TITLE
Hide actions dropdown in iTwin/iModel browser when no actions are defined

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/hide-empty-dropdown-table_2024-12-03-16-27.json
+++ b/common/changes/@itwin/imodel-browser-react/hide-empty-dropdown-table_2024-12-03-16-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Hide itwin/imodel actions dropdown when there are no actions defined",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { SvgMore } from "@itwin/itwinui-icons-react";
-import { DropdownMenu } from "@itwin/itwinui-react";
+import { DropdownMenu, IconButton } from "@itwin/itwinui-react";
 import React from "react";
 import { useMemo } from "react";
 import { CellProps } from "react-table";
@@ -76,30 +76,32 @@ export const useITwinTableConfig = ({
           },
           {
             id: "options",
-            style: { width: "50px" },
             disableSortBy: true,
-            maxWidth: 50,
+            maxWidth: 65,
             Cell: (props: CellProps<ITwinFull>) => {
-              const moreOptions = () => {
+              const moreOptions = (close: () => void) => {
                 const options = _buildManagedContextMenuOptions(
                   iTwinActions,
-                  props.row.original
+                  props.row.original,
+                  close
                 );
                 return options !== undefined ? options : [];
               };
 
-              return (
+              return iTwinActions && iTwinActions.length > 0 ? (
                 <DropdownMenu menuItems={moreOptions}>
-                  <div
+                  <IconButton
+                    styleType="borderless"
+                    aria-label="More options"
                     className="iac-options-icon"
                     onClick={(e) => {
                       e.stopPropagation();
                     }}
                   >
                     <SvgMore />
-                  </div>
+                  </IconButton>
                 </DropdownMenu>
-              );
+              ) : null;
             },
           },
         ],

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { SvgMore } from "@itwin/itwinui-icons-react";
-import { DropdownMenu } from "@itwin/itwinui-react";
+import { DropdownMenu, IconButton } from "@itwin/itwinui-react";
 import React from "react";
 import { useMemo } from "react";
 import { CellProps } from "react-table";
@@ -79,9 +79,8 @@ export const useIModelTableConfig = ({
           },
           {
             id: "options",
-            style: { width: "50px" },
             disableSortBy: true,
-            maxWidth: 50,
+            maxWidth: 65,
             Cell: (props: CellProps<IModelFull>) => {
               const moreOptions = (close: () => void) => {
                 const options = _buildManagedContextMenuOptions(
@@ -92,18 +91,20 @@ export const useIModelTableConfig = ({
                 return options !== undefined ? options : [];
               };
 
-              return (
+              return iModelActions && iModelActions.length > 0 ? (
                 <DropdownMenu menuItems={moreOptions}>
-                  <div
+                  <IconButton
+                    styleType="borderless"
+                    aria-label="More options"
                     className="iac-options-icon"
                     onClick={(e) => {
                       e.stopPropagation();
                     }}
                   >
                     <SvgMore />
-                  </div>
+                  </IconButton>
                 </DropdownMenu>
-              );
+              ) : null;
             },
           },
         ],


### PR DESCRIPTION
![Hide-dropdown-table](https://github.com/user-attachments/assets/2786df00-5b96-45f0-bcf6-2aba395aca42)
