### PR TITLE
Fix optional chaining for links in ITwinGrid state management

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/create-new-tag_2024-12-04-18-58.json
+++ b/common/changes/@itwin/imodel-browser-react/create-new-tag_2024-12-04-18-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix iTwin favorites and hide actions dropdown in iTwin/iModel browser when no actions defined",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
@@ -190,11 +190,11 @@ const useIndividualState: IndividualITwinStateHook = (iTwin, props) => {
           const data: IModelsFetchData = await response.json();
           setIModels(data.iModels);
           setLinks([
-            data._links.prev.href !== data._links.self.href
-              ? data._links.prev.href
+            data._links.prev?.href !== data._links.self.href
+              ? data._links.prev?.href
               : undefined,
-            data._links.next.href !== data._links.self.href
-              ? data._links.next.href
+            data._links.next?.href !== data._links.self.href
+              ? data._links.next?.href
               : undefined,
           ]);
           if (data.iModels.length === 0) {

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinFavorites.ts
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinFavorites.ts
@@ -202,10 +202,10 @@ interface ITwinFavoritesResponse {
     self: {
       href: string;
     };
-    prev: {
+    prev?: {
       href: string;
     };
-    next: {
+    next?: {
       href: string;
     };
   };


### PR DESCRIPTION
The dropdown was not opening because on first fetch there was no prev links.