### PR TITLE
Update ITwinGridProps accessToken documentation to specify memoization

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/itwin-grid-doc_2024-12-11-20-54.json
+++ b/common/changes/@itwin/imodel-browser-react/itwin-grid-doc_2024-12-11-20-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Update access token docs for iTwinGrid and iModelGrid",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -61,7 +61,7 @@ export interface ITwinGridStrings {
 }
 
 export interface ITwinGridProps {
-  /** Access token that requires the `itwins:read` scope. Must be memoized. Provide a function that returns the token to prevent the token from expiring. */
+  /** Access token that requires the `itwins:read` scope. Provide a function that returns the token to prevent the token from expiring. Function must be memoized. */
   accessToken?: string | (() => Promise<string>) | undefined;
   /** Type of iTwin to request */
   requestType?: "favorites" | "recents" | "";

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -61,7 +61,7 @@ export interface ITwinGridStrings {
 }
 
 export interface ITwinGridProps {
-  /** Access token that requires the `itwins:read` scope. Provide a function that returns the token to prevent the token from expiring. */
+  /** Access token that requires the `itwins:read` scope. Must be memoized. Provide a function that returns the token to prevent the token from expiring. */
   accessToken?: string | (() => Promise<string>) | undefined;
   /** Type of iTwin to request */
   requestType?: "favorites" | "recents" | "";

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -25,7 +25,7 @@ import { useIModelData } from "./useIModelData";
 import { useIModelTableConfig } from "./useIModelTableConfig";
 export interface IModelGridProps {
   /**
-   * Access token that requires the `imodels:read` scope. Must be memoized. Provide a function that returns the token to prevent the token from expiring. */
+   * Access token that requires the `imodels:read` scope. Provide a function that returns the token to prevent the token from expiring. Function must be memoized. */
   accessToken?: string | (() => Promise<string>) | undefined;
   /** ITwin Id to list the iModels from (mutually exclusive to assetId) */
   iTwinId?: string | undefined;


### PR DESCRIPTION
For external packages using this package, specify that accessToken has to be memoized in its function form.