### PR TITLE
Refresh grid on iTwin/iModel action

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/rerender-grid-on-action_2024-12-18-16-51.json
+++ b/common/changes/@itwin/imodel-browser-react/rerender-grid-on-action_2024-12-18-16-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "provide option to refresh the grid after an itwin/imodel action",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -216,7 +216,7 @@ const useIndividualState = (iModel: IModelFull, props: IModelTileProps) => {
     }),
     [fetchVersionsList, selection?.displayName, versions]
   );
-  // Override the thumbnailClick so it recieves the selected version too.
+  // Override the thumbnailClick so it receives the selected version too.
   // Not great typewise, but it is an example of what someone could do if it was really needed.
   const onThumbnailClick = React.useCallback(
     (iModel: IModelFull) => {
@@ -241,7 +241,7 @@ export const WithPostProcessCallback: Story<IModelGridProps> =
     withAccessTokenOverride((args) => {
       const [filter, setFilter] = React.useState("");
       const filterOrAddStartTile = React.useCallback(
-        (iModels: IModelFull[], status: DataStatus) => {
+        (iModels: IModelFull[], status?: DataStatus) => {
           if (status !== DataStatus.Complete) {
             return iModels;
           }

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.test.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.test.tsx
@@ -24,6 +24,7 @@ describe("ITwinGrid", () => {
       ],
       status: DataStatus.Complete,
       fetchMore: undefined,
+      refetchITwins: jest.fn(),
     });
   });
 
@@ -37,6 +38,7 @@ describe("ITwinGrid", () => {
       iTwins: [],
       status: DataStatus.Complete,
       fetchMore: undefined,
+      refetchITwins: jest.fn(),
     });
 
     // Act
@@ -58,11 +60,11 @@ describe("ITwinGrid", () => {
 
   it("should not refetch iTwins favorites when component rerenders", async () => {
     // Arrange
-    const fetchMore = jest.fn();
     jest.spyOn(useITwinData, "useITwinData").mockReturnValue({
       iTwins: [],
       status: DataStatus.Complete,
-      fetchMore,
+      fetchMore: jest.fn(),
+      refetchITwins: jest.fn(),
     });
     // Act
     const signal = new AbortController().signal;

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -123,6 +123,7 @@ export const ITwinGrid = ({
     shouldRefetchFavorites,
     resetShouldRefetchFavorites,
   } = useITwinFavorites(accessToken, apiOverrides?.serverEnvironmentPrefix);
+  const [isStale, setIsStale] = React.useState(false);
 
   const strings = _mergeStrings(
     {
@@ -153,6 +154,8 @@ export const ITwinGrid = ({
     filterOptions,
     shouldRefetchFavorites,
     resetShouldRefetchFavorites,
+    isStaleData: isStale,
+    resetStaleData: React.useCallback(() => setIsStale(false), []),
   });
 
   const iTwins = React.useMemo(
@@ -161,6 +164,10 @@ export const ITwinGrid = ({
     [postProcessCallback, fetchedItwins, fetchStatus]
   );
 
+  const forceRefresh = React.useCallback(() => {
+    setIsStale(true);
+  }, []);
+
   const { columns, onRowClick } = useITwinTableConfig({
     iTwinActions,
     onThumbnailClick,
@@ -168,6 +175,7 @@ export const ITwinGrid = ({
     iTwinFavorites,
     addITwinToFavorites,
     removeITwinFromFavorites,
+    forceRefresh,
   });
 
   const noResultsText = {
@@ -211,6 +219,7 @@ export const ITwinGrid = ({
                 isFavorite={iTwinFavorites.has(iTwin.id)}
                 addToFavorites={addITwinToFavorites}
                 removeFromFavorites={removeITwinFromFavorites}
+                forceRefresh={forceRefresh}
                 {...tileOverrides}
               />
             ))}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -123,7 +123,6 @@ export const ITwinGrid = ({
     shouldRefetchFavorites,
     resetShouldRefetchFavorites,
   } = useITwinFavorites(accessToken, apiOverrides?.serverEnvironmentPrefix);
-  const [isStale, setIsStale] = React.useState(false);
 
   const strings = _mergeStrings(
     {
@@ -146,6 +145,7 @@ export const ITwinGrid = ({
     iTwins: fetchedItwins,
     status: fetchStatus,
     fetchMore,
+    refetchITwins,
   } = useITwinData({
     requestType,
     iTwinSubClass,
@@ -154,8 +154,6 @@ export const ITwinGrid = ({
     filterOptions,
     shouldRefetchFavorites,
     resetShouldRefetchFavorites,
-    isStaleData: isStale,
-    resetStaleData: React.useCallback(() => setIsStale(false), []),
   });
 
   const iTwins = React.useMemo(
@@ -164,10 +162,6 @@ export const ITwinGrid = ({
     [postProcessCallback, fetchedItwins, fetchStatus]
   );
 
-  const forceRefresh = React.useCallback(() => {
-    setIsStale(true);
-  }, []);
-
   const { columns, onRowClick } = useITwinTableConfig({
     iTwinActions,
     onThumbnailClick,
@@ -175,7 +169,7 @@ export const ITwinGrid = ({
     iTwinFavorites,
     addITwinToFavorites,
     removeITwinFromFavorites,
-    forceRefresh,
+    refetchITwins,
   });
 
   const noResultsText = {
@@ -219,7 +213,7 @@ export const ITwinGrid = ({
                 isFavorite={iTwinFavorites.has(iTwin.id)}
                 addToFavorites={addITwinToFavorites}
                 removeFromFavorites={removeITwinFromFavorites}
-                forceRefresh={forceRefresh}
+                refetchITwins={refetchITwins}
                 {...tileOverrides}
               />
             ))}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -45,7 +45,7 @@ export interface ITwinTileProps {
   /**  Function to remove the iTwin from favorites  */
   removeFromFavorites?(iTwinId: string): Promise<void>;
   /** Function to force a refetch of the iTwins */
-  forceRefresh: () => void;
+  forceRefresh?: () => void;
 }
 
 /**
@@ -74,8 +74,14 @@ export const ITwinTile = ({
   );
 
   const moreOptions = React.useMemo(
-    () => _buildManagedContextMenuOptions(iTwinOptions, iTwin),
-    [iTwinOptions, iTwin]
+    () =>
+      _buildManagedContextMenuOptions(
+        iTwinOptions,
+        iTwin,
+        undefined,
+        forceRefresh
+      ),
+    [iTwinOptions, iTwin, forceRefresh]
   );
   return (
     <ThemeProvider theme="inherit">

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -44,8 +44,8 @@ export interface ITwinTileProps {
   addToFavorites?(iTwinId: string): Promise<void>;
   /**  Function to remove the iTwin from favorites  */
   removeFromFavorites?(iTwinId: string): Promise<void>;
-  /** Function to force a refetch of the iTwins */
-  forceRefresh?: () => void;
+  /** Function to refetch iTwins */
+  refetchITwins?: () => void;
 }
 
 /**
@@ -60,7 +60,7 @@ export const ITwinTile = ({
   isFavorite,
   addToFavorites,
   removeFromFavorites,
-  forceRefresh,
+  refetchITwins,
 }: ITwinTileProps) => {
   const strings = _mergeStrings(
     {
@@ -79,9 +79,9 @@ export const ITwinTile = ({
         iTwinOptions,
         iTwin,
         undefined,
-        forceRefresh
+        refetchITwins
       ),
-    [iTwinOptions, iTwin, forceRefresh]
+    [iTwinOptions, iTwin, refetchITwins]
   );
   return (
     <ThemeProvider theme="inherit">

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -44,6 +44,8 @@ export interface ITwinTileProps {
   addToFavorites?(iTwinId: string): Promise<void>;
   /**  Function to remove the iTwin from favorites  */
   removeFromFavorites?(iTwinId: string): Promise<void>;
+  /** Function to force a refetch of the iTwins */
+  forceRefresh: () => void;
 }
 
 /**
@@ -58,6 +60,7 @@ export const ITwinTile = ({
   isFavorite,
   addToFavorites,
   removeFromFavorites,
+  forceRefresh,
 }: ITwinTileProps) => {
   const strings = _mergeStrings(
     {

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
@@ -22,6 +22,8 @@ export interface ProjectDataHookOptions {
   filterOptions?: ITwinFilterOptions;
   shouldRefetchFavorites?: boolean;
   resetShouldRefetchFavorites?: () => void;
+  isStaleData?: boolean;
+  resetStaleData?: () => void;
 }
 
 const PAGE_SIZE = 100;
@@ -34,6 +36,8 @@ export const useITwinData = ({
   filterOptions,
   shouldRefetchFavorites,
   resetShouldRefetchFavorites,
+  isStaleData,
+  resetStaleData,
 }: ProjectDataHookOptions) => {
   const data = apiOverrides?.data;
   const serverEnvironmentPrefix = apiOverrides?.serverEnvironmentPrefix;
@@ -42,6 +46,17 @@ export const useITwinData = ({
   const filteredProjects = useITwinFilter(projects, filterOptions);
   const [page, setPage] = React.useState(0);
   const [morePages, setMorePages] = React.useState(true);
+
+  React.useEffect(() => {
+    if (isStaleData) {
+      setStatus(DataStatus.Fetching);
+      setProjects([]);
+      setPage(0);
+      setMorePages(true);
+      resetStaleData?.();
+    }
+  }, [isStaleData, resetStaleData]);
+
   const fetchMore = React.useCallback(() => {
     setPage((page) => page + 1);
   }, []);

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
@@ -22,7 +22,7 @@ export interface useITwinTableConfigProps {
   iTwinFavorites: Set<string>;
   addITwinToFavorites: (iTwinId: string) => Promise<void>;
   removeITwinFromFavorites: (iTwinId: string) => Promise<void>;
-  forceRefresh: () => void;
+  refetchITwins: () => void;
 }
 
 export const useITwinTableConfig = ({
@@ -32,7 +32,7 @@ export const useITwinTableConfig = ({
   iTwinFavorites,
   addITwinToFavorites,
   removeITwinFromFavorites,
-  forceRefresh,
+  refetchITwins,
 }: useITwinTableConfigProps) => {
   const onRowClick = (_: React.MouseEvent, row: any) => {
     const iTwin = row.original as ITwinFull;
@@ -113,7 +113,7 @@ export const useITwinTableConfig = ({
                   iTwinActions,
                   props.row.original,
                   close,
-                  forceRefresh
+                  refetchITwins
                 );
                 return options !== undefined ? options : [];
               };
@@ -148,7 +148,7 @@ export const useITwinTableConfig = ({
       strings.tableColumnFavorites,
       strings.tableColumnLastModified,
       strings.tableColumnName,
-      forceRefresh,
+      refetchITwins,
     ]
   );
 

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
@@ -22,6 +22,7 @@ export interface useITwinTableConfigProps {
   iTwinFavorites: Set<string>;
   addITwinToFavorites: (iTwinId: string) => Promise<void>;
   removeITwinFromFavorites: (iTwinId: string) => Promise<void>;
+  forceRefresh: () => void;
 }
 
 export const useITwinTableConfig = ({
@@ -31,6 +32,7 @@ export const useITwinTableConfig = ({
   iTwinFavorites,
   addITwinToFavorites,
   removeITwinFromFavorites,
+  forceRefresh,
 }: useITwinTableConfigProps) => {
   const onRowClick = (_: React.MouseEvent, row: any) => {
     const iTwin = row.original as ITwinFull;
@@ -110,7 +112,8 @@ export const useITwinTableConfig = ({
                 const options = _buildManagedContextMenuOptions(
                   iTwinActions,
                   props.row.original,
-                  close
+                  close,
+                  forceRefresh
                 );
                 return options !== undefined ? options : [];
               };
@@ -145,6 +148,7 @@ export const useITwinTableConfig = ({
       strings.tableColumnFavorites,
       strings.tableColumnLastModified,
       strings.tableColumnName,
+      forceRefresh,
     ]
   );
 

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -111,6 +111,7 @@ export const IModelGrid = ({
 }: IModelGridProps) => {
   const [sort, setSort] = React.useState<IModelSortOptions>(sortOptions);
   const [isSortOnTable, setIsSortOnTable] = React.useState(false);
+  const [isStale, setIsStale] = React.useState(false);
 
   React.useEffect(() => {
     if (!isSortOnTable) {
@@ -157,6 +158,8 @@ export const IModelGrid = ({
     searchText,
     maxCount,
     viewMode,
+    isStaleData: isStale,
+    resetStaleData: React.useCallback(() => setIsStale(false), []),
   });
 
   const iModels = React.useMemo(
@@ -165,11 +168,15 @@ export const IModelGrid = ({
       fetchediModels,
     [postProcessCallback, fetchediModels, fetchStatus, searchText]
   );
+  const forceRefresh = React.useCallback(() => {
+    setIsStale(true);
+  }, []);
 
   const { columns, onRowClick } = useIModelTableConfig({
     iModelActions,
     onThumbnailClick,
     strings,
+    forceRefresh,
   });
 
   const noResultsText = {
@@ -206,6 +213,7 @@ export const IModelGrid = ({
                     onThumbnailClick={onThumbnailClick}
                     apiOverrides={tileApiOverrides}
                     useTileState={useIndividualState}
+                    forceRefresh={forceRefresh}
                     {...tileOverrides}
                   />
                 ))}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -111,7 +111,6 @@ export const IModelGrid = ({
 }: IModelGridProps) => {
   const [sort, setSort] = React.useState<IModelSortOptions>(sortOptions);
   const [isSortOnTable, setIsSortOnTable] = React.useState(false);
-  const [isStale, setIsStale] = React.useState(false);
 
   React.useEffect(() => {
     if (!isSortOnTable) {
@@ -150,6 +149,7 @@ export const IModelGrid = ({
     iModels: fetchediModels,
     status: fetchStatus,
     fetchMore,
+    refetchIModels,
   } = useIModelData({
     accessToken,
     apiOverrides,
@@ -158,8 +158,6 @@ export const IModelGrid = ({
     searchText,
     maxCount,
     viewMode,
-    isStaleData: isStale,
-    resetStaleData: React.useCallback(() => setIsStale(false), []),
   });
 
   const iModels = React.useMemo(
@@ -168,15 +166,12 @@ export const IModelGrid = ({
       fetchediModels,
     [postProcessCallback, fetchediModels, fetchStatus, searchText]
   );
-  const forceRefresh = React.useCallback(() => {
-    setIsStale(true);
-  }, []);
 
   const { columns, onRowClick } = useIModelTableConfig({
     iModelActions,
     onThumbnailClick,
     strings,
-    forceRefresh,
+    refetchIModels,
   });
 
   const noResultsText = {
@@ -213,7 +208,7 @@ export const IModelGrid = ({
                     onThumbnailClick={onThumbnailClick}
                     apiOverrides={tileApiOverrides}
                     useTileState={useIndividualState}
-                    forceRefresh={forceRefresh}
+                    refetchIModels={refetchIModels}
                     {...tileOverrides}
                   />
                 ))}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -27,14 +27,14 @@ export interface useIModelTableConfigProps {
     noAuthentication: string;
     error: string;
   };
-  forceRefresh: () => void;
+  refetchIModels: () => void;
 }
 
 export const useIModelTableConfig = ({
   iModelActions,
   onThumbnailClick,
   strings,
-  forceRefresh,
+  refetchIModels,
 }: useIModelTableConfigProps) => {
   const onRowClick = (_: React.MouseEvent, row: any) => {
     const iModel = row.original as IModelFull;
@@ -89,7 +89,7 @@ export const useIModelTableConfig = ({
                   iModelActions,
                   props.row.original,
                   close,
-                  forceRefresh
+                  refetchIModels
                 );
                 return options !== undefined ? options : [];
               };
@@ -118,7 +118,7 @@ export const useIModelTableConfig = ({
       strings.tableColumnDescription,
       strings.tableColumnLastModified,
       strings.tableColumnName,
-      forceRefresh,
+      refetchIModels,
     ]
   );
 

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -27,12 +27,14 @@ export interface useIModelTableConfigProps {
     noAuthentication: string;
     error: string;
   };
+  forceRefresh: () => void;
 }
 
 export const useIModelTableConfig = ({
   iModelActions,
   onThumbnailClick,
   strings,
+  forceRefresh,
 }: useIModelTableConfigProps) => {
   const onRowClick = (_: React.MouseEvent, row: any) => {
     const iModel = row.original as IModelFull;
@@ -86,7 +88,8 @@ export const useIModelTableConfig = ({
                 const options = _buildManagedContextMenuOptions(
                   iModelActions,
                   props.row.original,
-                  close
+                  close,
+                  forceRefresh
                 );
                 return options !== undefined ? options : [];
               };
@@ -115,6 +118,7 @@ export const useIModelTableConfig = ({
       strings.tableColumnDescription,
       strings.tableColumnLastModified,
       strings.tableColumnName,
+      forceRefresh,
     ]
   );
 

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -28,7 +28,7 @@ export interface IModelTileProps {
   /** Object that configures different overrides for the API */
   apiOverrides?: ApiOverrides;
   /** Function to force a refetch of the iModels */
-  forceRefresh: () => void;
+  forceRefresh?: () => void;
 }
 
 /**

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -27,6 +27,8 @@ export interface IModelTileProps {
   tileProps?: Partial<TileProps>;
   /** Object that configures different overrides for the API */
   apiOverrides?: ApiOverrides;
+  /** Function to force a refetch of the iModels */
+  forceRefresh: () => void;
 }
 
 /**
@@ -39,10 +41,17 @@ export const IModelTile = ({
   onThumbnailClick,
   apiOverrides,
   tileProps,
+  forceRefresh,
 }: IModelTileProps) => {
   const moreOptions = React.useMemo(
-    () => _buildManagedContextMenuOptions(iModelOptions, iModel),
-    [iModelOptions, iModel]
+    () =>
+      _buildManagedContextMenuOptions(
+        iModelOptions,
+        iModel,
+        undefined,
+        forceRefresh
+      ),
+    [iModelOptions, iModel, forceRefresh]
   );
   const thumbnailApiOverride =
     apiOverrides || iModel?.thumbnail

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -27,8 +27,8 @@ export interface IModelTileProps {
   tileProps?: Partial<TileProps>;
   /** Object that configures different overrides for the API */
   apiOverrides?: ApiOverrides;
-  /** Function to force a refetch of the iModels */
-  forceRefresh?: () => void;
+  /** Function to refetch iModels */
+  refetchIModels?: () => void;
 }
 
 /**
@@ -41,7 +41,7 @@ export const IModelTile = ({
   onThumbnailClick,
   apiOverrides,
   tileProps,
-  forceRefresh,
+  refetchIModels,
 }: IModelTileProps) => {
   const moreOptions = React.useMemo(
     () =>
@@ -49,9 +49,9 @@ export const IModelTile = ({
         iModelOptions,
         iModel,
         undefined,
-        forceRefresh
+        refetchIModels
       ),
-    [iModelOptions, iModel, forceRefresh]
+    [iModelOptions, iModel, refetchIModels]
   );
   const thumbnailApiOverride =
     apiOverrides || iModel?.thumbnail

--- a/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
+++ b/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
@@ -11,7 +11,7 @@ export interface ContextMenuBuilderItem<T = any>
   extends Omit<MenuItemProps, "onClick" | "value"> {
   key: string;
   visible?: boolean | ((value: T) => boolean);
-  onClick?: ((value: T, forceRefresh?: () => void) => void) | undefined;
+  onClick?: ((value?: T, forceRefresh?: () => void) => void) | undefined;
 }
 
 /** Build MenuItem array for the value for each provided options

--- a/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
+++ b/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
@@ -11,7 +11,7 @@ export interface ContextMenuBuilderItem<T = any>
   extends Omit<MenuItemProps, "onClick" | "value"> {
   key: string;
   visible?: boolean | ((value: T) => boolean);
-  onClick?: ((value?: T, forceRefresh?: () => void) => void) | undefined;
+  onClick?: ((value?: T, refetchData?: () => void) => void) | undefined;
 }
 
 /** Build MenuItem array for the value for each provided options
@@ -21,8 +21,8 @@ export const _buildManagedContextMenuOptions: <T>(
   options: ContextMenuBuilderItem<T>[] | undefined,
   value: T,
   closeMenu?: () => void,
-  forceRefresh?: () => void
-) => JSX.Element[] | undefined = (options, value, closeMenu, forceRefresh) => {
+  refetchData?: () => void
+) => JSX.Element[] | undefined = (options, value, closeMenu, refetchData) => {
   return options
     ?.filter?.(({ visible }) => {
       return typeof visible === "function" ? visible(value) : visible ?? true;
@@ -33,7 +33,7 @@ export const _buildManagedContextMenuOptions: <T>(
           {...contextMenuProps}
           onClick={() => {
             closeMenu?.();
-            onClick?.(value, forceRefresh);
+            onClick?.(value, refetchData);
           }}
           key={key}
           value={value}

--- a/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
+++ b/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
@@ -11,7 +11,7 @@ export interface ContextMenuBuilderItem<T = any>
   extends Omit<MenuItemProps, "onClick" | "value"> {
   key: string;
   visible?: boolean | ((value: T) => boolean);
-  onClick?: ((value?: unknown) => void) | undefined;
+  onClick?: ((value: T, forceRefresh?: () => void) => void) | undefined;
 }
 
 /** Build MenuItem array for the value for each provided options
@@ -20,8 +20,9 @@ export interface ContextMenuBuilderItem<T = any>
 export const _buildManagedContextMenuOptions: <T>(
   options: ContextMenuBuilderItem<T>[] | undefined,
   value: T,
-  closeMenu?: () => void
-) => JSX.Element[] | undefined = (options, value, closeMenu) => {
+  closeMenu?: () => void,
+  forceRefresh?: () => void
+) => JSX.Element[] | undefined = (options, value, closeMenu, forceRefresh) => {
   return options
     ?.filter?.(({ visible }) => {
       return typeof visible === "function" ? visible(value) : visible ?? true;
@@ -32,7 +33,7 @@ export const _buildManagedContextMenuOptions: <T>(
           {...contextMenuProps}
           onClick={() => {
             closeMenu?.();
-            onClick?.(value);
+            onClick?.(value, forceRefresh);
           }}
           key={key}
           value={value}


### PR DESCRIPTION
This PR provides an option for client to refresh the iTwin/iModel list after running an action.