### PR TITLE
accessibility improved for itwin/imodel grid tiles

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/nm-acessible-tiles_2025-01-10-00-19.json
+++ b/common/changes/@itwin/imodel-browser-react/nm-acessible-tiles_2025-01-10-00-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "added accessibility to grid tiles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -108,7 +108,10 @@ export const ITwinTile = ({
         moreOptions={moreOptions}
         thumbnail={
           <div
-            aria-label={onThumbnailClick ? strings.navigateToITwin : ""}
+            role="button"
+            aria-label={
+              onThumbnailClick ? `${strings.navigateToITwin} ${iTwin?.id}` : ""
+            }
             onClick={() => onThumbnailClick?.(iTwin)}
             style={{ cursor: onThumbnailClick ? "pointer" : "auto" }}
           >

--- a/packages/modules/imodel-browser/src/containers/iModelThumbnail/IModelThumbnail.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelThumbnail/IModelThumbnail.tsx
@@ -30,6 +30,7 @@ export interface IModelThumbnailProps {
 /** Clickable iModel thumbnail, fetched from the servers */
 export const IModelThumbnail = ({
   iModelId,
+  onClick,
   accessToken,
   apiOverrides,
   className,
@@ -44,7 +45,11 @@ export const IModelThumbnail = ({
     apiOverrides
   );
   return (
-    <div role="button" aria-label={`Select iModel ${iModelId}`}>
+    <div
+      role="button"
+      aria-label={`Select iModel ${iModelId}`}
+      onClick={() => onClick?.(iModelId)}
+    >
       {thumbnail ? (
         <img
           className={classNames("iac-thumbnail", className)}

--- a/packages/modules/imodel-browser/src/containers/iModelThumbnail/IModelThumbnail.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelThumbnail/IModelThumbnail.tsx
@@ -30,7 +30,6 @@ export interface IModelThumbnailProps {
 /** Clickable iModel thumbnail, fetched from the servers */
 export const IModelThumbnail = ({
   iModelId,
-  onClick,
   accessToken,
   apiOverrides,
   className,
@@ -44,25 +43,27 @@ export const IModelThumbnail = ({
     inView ? accessToken : undefined,
     apiOverrides
   );
-  return thumbnail ? (
-    <img
-      className={classNames("iac-thumbnail", className)}
-      style={{
-        cursor: onClick ? "pointer" : "auto",
-        width: "100%",
-      }}
-      id="base64image"
-      src={thumbnail ?? ""}
-      alt=""
-      onClick={() => onClick?.(iModelId)}
-    />
-  ) : (
-    <Text
-      as="p"
-      variant="body"
-      ref={ref}
-      isSkeleton={true}
-      style={{ height: "100%", width: "100%", margin: 0 }}
-    ></Text>
+  return (
+    <div role="button" aria-label={`Select iModel ${iModelId}`}>
+      {thumbnail ? (
+        <img
+          className={classNames("iac-thumbnail", className)}
+          style={{
+            width: "100%",
+          }}
+          id="base64image"
+          src={thumbnail ?? ""}
+          alt=""
+        />
+      ) : (
+        <Text
+          as="p"
+          variant="body"
+          ref={ref}
+          isSkeleton={true}
+          style={{ height: "100%", width: "100%", margin: 0 }}
+        ></Text>
+      )}
+    </div>
   );
 };


### PR DESCRIPTION
## Issue
- the imodel/itwin grid tiles were not very accessible
- this is necessary for both accessibility users and e2e testing where these components are used

## Changes
- aria labels and role=button added for the actionable elements in the tile

## Notes
- these changes are the *minimum* amount to provide accessibility _not_ the most ideal
- most ideal would be updating to @itwin/itwinui-react 3.x.x + and utilizing [actionable tiles](https://itwinui.bentley.com/docs/tile#actionable) which have native semantic accessibility implementation

## Screenshots
<img width="1047" alt="Screenshot 2025-01-09 at 7 28 49 PM" src="https://github.com/user-attachments/assets/eb7163ba-511e-4824-8199-e03e546eb1c9" />

## References
https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR35
https://testing-library.com/docs/queries/about/#priority