### PR TITLE
allow fetching all iTwins regardless of subclass

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/imodel-browser-allow-all-subclasses_2025-01-10-18-23.json
+++ b/common/changes/@itwin/imodel-browser-react/imodel-browser-allow-all-subclasses_2025-01-10-18-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "add ITwinSubClass \"All\" option to fetch all itwins regardless of subclass",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/apps/storybook/.env
+++ b/packages/apps/storybook/.env
@@ -1,3 +1,3 @@
-# Registered client which have access to scopes "imodels:read", "imodels:modify", "itwins:read" and "itwins:modify", redirectUrl should be http://localhost:6006/signin-oidc.html
+# Registered client which has access to the "itwin-platform" scope, redirectUrl should be http://localhost:6006/signin-oidc.html
 # Please create .env.local file and put the client id there to avoid accidentally commiting this file.
 STORYBOOK_AUTH_CLIENT_ID=

--- a/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
@@ -299,3 +299,9 @@ export const WithPostProcessCallback: Story<ITwinGridProps> =
 WithPostProcessCallback.args = {
   apiOverrides: { serverEnvironmentPrefix: "qa" },
 };
+
+export const FetchAllSubclasses = Template.bind({});
+FetchAllSubclasses.args = {
+  apiOverrides: { serverEnvironmentPrefix: "qa" },
+  iTwinSubClass: "All",
+};

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
@@ -103,7 +103,8 @@ export const useITwinData = ({
     const endpoint = ["favorites", "recents"].includes(requestType)
       ? requestType
       : "";
-    const subClass = `?subClass=${iTwinSubClass}`;
+    const resolvedITwinSubClass = iTwinSubClass === "All" ? "" : iTwinSubClass;
+    const subClass = `?subClass=${resolvedITwinSubClass}`;
     const paging = `&$skip=${page * PAGE_SIZE}&$top=${PAGE_SIZE}`;
     const search =
       ["favorites", "recents"].includes(requestType) || !filterOptions

--- a/packages/modules/imodel-browser/src/types.ts
+++ b/packages/modules/imodel-browser/src/types.ts
@@ -82,7 +82,8 @@ export type ITwinSubClass =
   | "Asset"
   | "Portfolio"
   | "Program"
-  | "WorkPackage";
+  | "WorkPackage"
+  | "All";
 export type ITwinClassType = "Thing" | "Endeavor";
 export type ITwinStatus =
   | "Active"


### PR DESCRIPTION
Adds the option to fetch all iTwins regardless of subclass. This is achieved by using an empty string for the `subClass` query parameter when utilizing the iTwins API. An `All` string literal has been added to the `iTwinSubClass` string literal union to expose this.
