### PR TITLE
Fix iModel browser skipping pages

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/fix-skipped-pages_2025-02-05-06-51.json
+++ b/common/changes/@itwin/imodel-browser-react/fix-skipped-pages_2025-02-05-06-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix iModel browser skipping pages",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -205,9 +205,12 @@ export const IModelGrid = ({
               />
             ))}
             {fetchMore ? (
-              <InView>
-                {({ inView, ref }) => {
+              <InView
+                onChange={(inView) => {
                   inView && fetchStatus !== DataStatus.Fetching && fetchMore();
+                }}
+              >
+                {({ ref }) => {
                   return <IModelGhostTile ref={ref} />;
                 }}
               </InView>

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -71,12 +71,12 @@ export const useIModelData = ({
   }, []);
 
   const fetchMore = React.useCallback(() => {
-    if (status === DataStatus.Fetching || !morePagesAvailable) {
+    if (needsUpdate || status === DataStatus.Fetching || !morePagesAvailable) {
       return;
     }
     setPage((prev) => prev + 1);
     setNeedsUpdate(true);
-  }, [status, morePagesAvailable]);
+  }, [needsUpdate, status, morePagesAvailable]);
 
   React.useEffect(() => {
     // start from scratch when any external state changes

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -74,9 +74,9 @@ export const useIModelData = ({
     if (needsUpdate || status === DataStatus.Fetching || !morePagesAvailable) {
       return;
     }
-    setPage((prev) => prev + 1);
+    setPage(page + 1);
     setNeedsUpdate(true);
-  }, [needsUpdate, status, morePagesAvailable]);
+  }, [needsUpdate, status, morePagesAvailable, page]);
 
   React.useEffect(() => {
     // start from scratch when any external state changes


### PR DESCRIPTION
The iModel browser was sometimes skipping pages, leading to only showing 100 iModels in an iTwin with 100-200 iModels. 

This was caused by a race condition that I could not reproduce in a test or in the storybook, which is why I did not add a unit test.

I also fixed a warning that the state was being updated in the render phase.

In this screenshot demonstrating the issues, I added some console logs to debug. Notice that the page jumps from 0 to 2.
![image](https://github.com/user-attachments/assets/d51a42ea-a637-4404-a024-bad0819aa576)