### PR TITLE
Fixed iModel descriptions missing from iModelGrid

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/DanishM-description_2025-04-14-08-33.json
+++ b/common/changes/@itwin/imodel-browser-react/DanishM-description_2025-04-14-08-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fixed imodel descriptions not visible in iModelGrid",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -112,6 +112,7 @@ export const IModelTile = ({
         <Tile.NameLabel>{name ?? iModel?.displayName}</Tile.NameLabel>
       </Tile.Name>
       <Tile.ContentArea>
+        <Tile.Description>{iModel?.description ?? ""}</Tile.Description>
         {(moreOptions || moreOptionsBuilt) && (
           <Tile.MoreOptions>{moreOptions ?? moreOptionsBuilt}</Tile.MoreOptions>
         )}


### PR DESCRIPTION
Part 1 of [workitem](https://dev.azure.com/bentleycs/iModelTechnologies/_boards/board/t/iTwin%20Studio%20-%20Nebula/Backlog%20items?System.IterationPath=iModelTechnologies%5CiTwin%20Studio%5CNebula%5CMay2025&workitem=1643618)

![image](https://github.com/user-attachments/assets/d4d332bb-867c-4ad8-9eed-f5e2f8838b7c)

