### PR TITLE
Fix iModelBrowser menu items in table view always opening iModel

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/fix-menu-click_2025-04-17-14-08.json
+++ b/common/changes/@itwin/imodel-browser-react/fix-menu-click_2025-04-17-14-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix Menu click invoking table row click",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -92,7 +92,12 @@ export const useIModelTableConfig = ({
               };
 
               return iModelActions && iModelActions.length > 0 ? (
-                <DropdownMenu menuItems={moreOptions}>
+                <DropdownMenu
+                  menuItems={moreOptions}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
                   <IconButton
                     styleType="borderless"
                     aria-label="More options"

--- a/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
+++ b/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
@@ -29,15 +29,17 @@ export const _buildManagedContextMenuOptions: <T>(
     })
     .map(({ key, visible, onClick, ...contextMenuProps }) => {
       return (
-        <MenuItem
-          {...contextMenuProps}
-          onClick={() => {
-            closeMenu?.();
-            onClick?.(value, refetchData);
-          }}
-          key={key}
-          value={value}
-        />
+        // MenuItem doesn't expose the real click event, so wrap it in div to intercept it and stop propagation
+        <div key={key} onClick={(e) => e.stopPropagation()}>
+          <MenuItem
+            {...contextMenuProps}
+            onClick={() => {
+              closeMenu?.();
+              onClick?.(value, refetchData);
+            }}
+            value={value}
+          />
+        </div>
       );
     });
 };

--- a/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
+++ b/packages/modules/imodel-browser/src/utils/_buildMenuOptions.tsx
@@ -29,17 +29,15 @@ export const _buildManagedContextMenuOptions: <T>(
     })
     .map(({ key, visible, onClick, ...contextMenuProps }) => {
       return (
-        // MenuItem doesn't expose the real click event, so wrap it in div to intercept it and stop propagation
-        <div key={key} onClick={(e) => e.stopPropagation()}>
-          <MenuItem
-            {...contextMenuProps}
-            onClick={() => {
-              closeMenu?.();
-              onClick?.(value, refetchData);
-            }}
-            value={value}
-          />
-        </div>
+        <MenuItem
+          {...contextMenuProps}
+          onClick={() => {
+            closeMenu?.();
+            onClick?.(value, refetchData);
+          }}
+          key={key}
+          value={value}
+        />
       );
     });
 };


### PR DESCRIPTION
The iTwinUI `MenuItem` was always bubbling the click event, which triggered the table row click event that opens the iModel.

`MenuItem` doesn't expose the real click event, so I wrapped it in a div to intercept it and stop it from bubbling.