### PR TITLE
iTwin Search box not working with plus sign character

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/omar-fix-itwin-search_2025-04-17-16-28.json
+++ b/common/changes/@itwin/imodel-browser-react/omar-fix-itwin-search_2025-04-17-16-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "fix error when searching itwin",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
@@ -109,7 +109,7 @@ export const useITwinData = ({
     const search =
       ["favorites", "recents"].includes(requestType) || !filterOptions
         ? ""
-        : `&$search=${filterOptions}`;
+        : `&$search=${encodeURIComponent(String(filterOptions).trim())}`;
     const url = `${_getAPIServer(
       serverEnvironmentPrefix
     )}/itwins/${endpoint}${subClass}${paging}${search}`;


### PR DESCRIPTION
Encoded the search string to account for special characters that end up in the url search
![image](https://github.com/user-attachments/assets/2cb849e4-17d9-41a1-b286-065a2227c541)
