### PR TITLE
Fixed the infinite scroll issue on named version page.

### DIFF
--- a/packages/modules/manage-versions/src/clients/namedVersionClient.test.ts
+++ b/packages/modules/manage-versions/src/clients/namedVersionClient.test.ts
@@ -21,7 +21,7 @@ describe("NamedVersionClient", () => {
 
     await namedVersionClient.get(MOCKED_IMODEL_ID);
     expect(mockHttpGet).toHaveBeenCalledWith(
-      `https://api.bentley.com/imodels/${MOCKED_IMODEL_ID}/namedversions`,
+      `https://api.bentley.com/imodels/${MOCKED_IMODEL_ID}/namedversions?$orderBy=changesetIndex+desc`,
       {
         headers: {
           Prefer: "return=representation",
@@ -36,7 +36,7 @@ describe("NamedVersionClient", () => {
 
     await namedVersionClient.get(MOCKED_IMODEL_ID, { top: 10, skip: 20 });
     expect(mockHttpGet).toHaveBeenCalledWith(
-      `https://api.bentley.com/imodels/${MOCKED_IMODEL_ID}/namedversions?$top=10&$skip=20`,
+      `https://api.bentley.com/imodels/${MOCKED_IMODEL_ID}/namedversions?$orderBy=changesetIndex+desc&$top=10&$skip=20`,
       {
         headers: {
           Prefer: "return=representation",

--- a/packages/modules/manage-versions/src/clients/namedVersionClient.ts
+++ b/packages/modules/manage-versions/src/clients/namedVersionClient.ts
@@ -27,7 +27,10 @@ export class NamedVersionClient {
           imodelId,
           undefined,
           this._serverEnvironmentPrefix
-        )}${UrlBuilder.getQuery(requestOptions)}`,
+        )}${UrlBuilder.getQuery({
+          orderBy: "changesetIndex+desc",
+          ...requestOptions,
+        })}`,
         {
           headers: {
             [HttpHeaderNames.Prefer]: "return=representation",

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.tsx
@@ -108,10 +108,23 @@ const initialChangeset: Changeset = {
 const initializeVersionTableData = (
   versions: NamedVersion[],
   versionTableData?: VersionTableData[],
-  reloadSubrows?: boolean
+  reloadSubrows?: boolean,
+  appendVersions?: boolean
 ): VersionTableData[] => {
-  return (versions ?? []).map((version, index) => {
-    const existingData = versionTableData?.[index];
+  const existingVersions =
+    versionTableData?.map((versionTableData) => versionTableData.version) ?? [];
+  const allVersions = appendVersions
+    ? [...existingVersions, ...versions]
+    : versions;
+  const versionsTableDataMap = new Map(
+    versionTableData?.map((versionTableData) => [
+      versionTableData.version.id,
+      versionTableData,
+    ])
+  );
+
+  return allVersions.map((version) => {
+    const existingData = versionsTableDataMap.get(version.id);
     const defaultSubRows = reloadSubrows
       ? [initialChangeset]
       : existingData?.subRows ?? [initialChangeset];
@@ -243,7 +256,8 @@ export const ManageVersions = (props: ManageVersionsProps) => {
             ...initializeVersionTableData(
               updateVersions ?? [],
               oldVersions,
-              reloadSubrows
+              reloadSubrows,
+              skip !== undefined
             ),
           ]);
           setVersionStatus(RequestStatus.Finished);


### PR DESCRIPTION
Changes: 
1. Updated the query to fetch the named version of the latest changes first.
2. Fixed the infinite scroll issue

Issue: 
1. If there are more than 100 named versions then in first call it is not fetching the named versions of the latest changes.
2. After infinite scroll it only shows the remaining (other than first 100 named version)
