### PR TITLE
Refactor IModelTile component to allow hovering over name label

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/omar-fix-imodel-tile-name_2025-07-10-16-14.json
+++ b/common/changes/@itwin/imodel-browser-react/omar-fix-imodel-tile-name_2025-07-10-16-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Refactor IModelTile component to allow hovering over name label",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -93,14 +93,11 @@ export const IModelTile = ({
     >
       <Tile.Name>
         <Tile.NameIcon />
-        <Tile.NameLabel>
-          <Tile.Action
-            onClick={(e) => onClick?.(e) ?? onThumbnailClick?.(iModel)}
-            aria-disabled={isDisabled}
-            data-testid={`iModel-tile-${iModel.id}`}
-          >
-            {name ?? iModel.displayName}
-          </Tile.Action>
+        <Tile.NameLabel
+          onClick={(e) => onClick?.(e) ?? onThumbnailClick?.(iModel)}
+          aria-disabled={isDisabled}
+        >
+          {name ?? iModel.displayName}
         </Tile.NameLabel>
       </Tile.Name>
       <Tile.ThumbnailArea>
@@ -121,12 +118,20 @@ export const IModelTile = ({
           </Tile.BadgeContainer>
         )}
       </Tile.ThumbnailArea>
-      <Tile.ContentArea>
-        <Tile.Description>{iModel?.description ?? ""}</Tile.Description>
-        {(moreOptions || moreOptionsBuilt) && (
-          <Tile.MoreOptions>{moreOptions ?? moreOptionsBuilt}</Tile.MoreOptions>
-        )}
-      </Tile.ContentArea>
+      <Tile.Action
+        onClick={(e) => onClick?.(e) ?? onThumbnailClick?.(iModel)}
+        aria-disabled={isDisabled}
+        data-testid={`iModel-tile-${iModel.id}`}
+      >
+        <Tile.ContentArea>
+          <Tile.Description>{iModel?.description ?? ""}</Tile.Description>
+          {(moreOptions || moreOptionsBuilt) && (
+            <Tile.MoreOptions>
+              {moreOptions ?? moreOptionsBuilt}
+            </Tile.MoreOptions>
+          )}
+        </Tile.ContentArea>
+      </Tile.Action>
       {buttons && <Tile.Buttons>{buttons}</Tile.Buttons>}
     </Tile.Wrapper>
   );


### PR DESCRIPTION
When using a component for the iModel tile name, the component wouldn't pick up the hover.
Before:
![tile-name-hover-before](https://github.com/user-attachments/assets/5f9721bc-39d7-4b1b-9a54-a2bf2b82ac9b)
After:
![tile-name-hover-after](https://github.com/user-attachments/assets/57d95275-df12-451f-b35f-ef7022aa229e)
