### PR TITLE
Fix imodel actions triggering onThumbnail click

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/omar-fix-imodel-action-opening_2025-07-10-23-24.json
+++ b/common/changes/@itwin/imodel-browser-react/omar-fix-imodel-action-opening_2025-07-10-23-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix iModel opening when opening action dropdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -118,20 +118,18 @@ export const IModelTile = ({
           </Tile.BadgeContainer>
         )}
       </Tile.ThumbnailArea>
-      <Tile.Action
-        onClick={(e) => onClick?.(e) ?? onThumbnailClick?.(iModel)}
-        aria-disabled={isDisabled}
-        data-testid={`iModel-tile-${iModel.id}`}
-      >
-        <Tile.ContentArea>
+      <Tile.ContentArea>
+        <Tile.Action
+          onClick={(e) => onClick?.(e) ?? onThumbnailClick?.(iModel)}
+          aria-disabled={isDisabled}
+          data-testid={`iModel-tile-${iModel.id}`}
+        >
           <Tile.Description>{iModel?.description ?? ""}</Tile.Description>
-          {(moreOptions || moreOptionsBuilt) && (
-            <Tile.MoreOptions>
-              {moreOptions ?? moreOptionsBuilt}
-            </Tile.MoreOptions>
-          )}
-        </Tile.ContentArea>
-      </Tile.Action>
+        </Tile.Action>
+        {(moreOptions || moreOptionsBuilt) && (
+          <Tile.MoreOptions>{moreOptions ?? moreOptionsBuilt}</Tile.MoreOptions>
+        )}
+      </Tile.ContentArea>
       {buttons && <Tile.Buttons>{buttons}</Tile.Buttons>}
     </Tile.Wrapper>
   );


### PR DESCRIPTION
My recent PR broke the iModel actions. Clicking on iModel actions would trigger the onThumbnail click.