### PR TITLE
Add cellOverrides option to iModelGrid and iTwinGrid

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/omar-cell-overrides-in-imodelgrid_2025-07-12-05-49.json
+++ b/common/changes/@itwin/imodel-browser-react/omar-cell-overrides-in-imodelgrid_2025-07-12-05-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Add cellOverrides option to iModelGrid and iTwinGrid",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       '@itwin/delete-imodel-react': workspace:*
       '@itwin/delete-itwin-react': workspace:*
       '@itwin/imodel-browser-react': workspace:*
+      '@itwin/itwinui-icons-react': 2.10.0
       '@itwin/itwinui-react': 3.18.0
       '@itwin/manage-versions-react': workspace:*
       '@itwin/storybook-auth-addon': workspace:*
@@ -64,6 +65,7 @@ importers:
       '@itwin/delete-imodel-react': link:../../modules/delete-imodel
       '@itwin/delete-itwin-react': link:../../modules/delete-itwin
       '@itwin/imodel-browser-react': link:../../modules/imodel-browser
+      '@itwin/itwinui-icons-react': 2.10.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 3.18.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/manage-versions-react': link:../../modules/manage-versions
       '@itwin/storybook-auth-addon': link:../../modules/storybook-auth-addon
@@ -338,6 +340,7 @@ importers:
       '@rollup/plugin-commonjs': ~17.1.0
       '@rollup/plugin-url': ^8.0.1
       '@svgr/rollup': ^5.5.0
+      '@testing-library/jest-dom': ^6.6.3
       '@testing-library/react': ^11.1.0
       '@testing-library/react-hooks': ^5.1.0
       '@types/jest': ^27.5.1
@@ -392,6 +395,7 @@ importers:
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.79.2
       '@rollup/plugin-url': 8.0.2_rollup@2.79.2
       '@svgr/rollup': 5.5.0
+      '@testing-library/jest-dom': 6.6.3
       '@testing-library/react': 11.2.7_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/react-hooks': 5.1.3_fs7zzattp7ispciphqk72hx22m
       '@types/jest': 27.5.2
@@ -2805,7 +2809,6 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-    dev: false
 
   /@itwin/itwinui-illustrations-react/2.1.0_nnrd3gsncyragczmpvfhocinkq:
     resolution: {integrity: sha512-5JR2A3mZy0d0qwwHpveSG3fsXLheJkO6a0GoWb8NQWw5edNZMRynJg0l3hVw3CHMgaaCGbUoKC77MuG0jWDzuA==}

--- a/packages/apps/storybook/package.json
+++ b/packages/apps/storybook/package.json
@@ -13,6 +13,7 @@
     "@itwin/delete-imodel-react": "workspace:*",
     "@itwin/delete-itwin-react": "workspace:*",
     "@itwin/imodel-browser-react": "workspace:*",
+    "@itwin/itwinui-icons-react": "2.10.0",
     "@itwin/itwinui-react": "3.18.0",
     "@itwin/manage-versions-react": "workspace:*",
     "@itwin/storybook-auth-addon": "workspace:*",

--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -61,12 +61,13 @@ PrimaryCell.args = {
 export const OverrideCellData = Template.bind({});
 OverrideCellData.args = {
   apiOverrides: { serverEnvironmentPrefix: "qa" },
+  viewMode: "cells",
   cellOverrides: {
     name: (props) => (
       <div>
         <IconButton size="small" styleType="borderless">
           <SvgStar />
-        </IconButton>{" "}
+        </IconButton>
         {props.value}
       </div>
     ),

--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -64,7 +64,7 @@ OverrideCellData.args = {
   viewMode: "cells",
   cellOverrides: {
     name: (props) => (
-      <div>
+      <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
         <IconButton size="small" styleType="borderless">
           <SvgStar />
         </IconButton>

--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -9,10 +9,12 @@ import {
   IModelGridProps,
   IModelTileProps,
 } from "@itwin/imodel-browser-react";
+import { SvgStar } from "@itwin/itwinui-icons-react";
 import {
   Button,
   Code,
   DropdownButton,
+  IconButton,
   LabeledInput,
   MenuItem,
   MenuItemSkeleton,
@@ -54,6 +56,22 @@ export const PrimaryCell = Template.bind({});
 PrimaryCell.args = {
   apiOverrides: { serverEnvironmentPrefix: "qa" },
   viewMode: "cells",
+};
+
+export const OverrideCellData = Template.bind({});
+OverrideCellData.args = {
+  apiOverrides: { serverEnvironmentPrefix: "qa" },
+  cellOverrides: {
+    name: (props) => (
+      <div>
+        <IconButton size="small" styleType="borderless">
+          <SvgStar />
+        </IconButton>{" "}
+        {props.value}
+      </div>
+    ),
+    description: (props) => <em>{props.value}</em>,
+  },
 };
 
 export const OverrideApiData = Template.bind({});

--- a/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
@@ -9,7 +9,7 @@ import {
   ITwinGrid as ExternalComponent,
   ITwinGridProps,
 } from "@itwin/imodel-browser-react";
-import { SvgStar } from "@itwin/itwinui-icons-react";
+import { SvgHeart } from "@itwin/itwinui-icons-react";
 import {
   Button,
   Code,
@@ -58,7 +58,7 @@ OverrideCellData.args = {
   viewMode: "cells",
   cellOverrides: {
     ITwinNumber: (props) => (
-      <div>
+      <strong>
         <IconButton
           size="small"
           styleType="borderless"
@@ -67,11 +67,12 @@ OverrideCellData.args = {
             console.log("Icon Clicked");
           }}
         >
-          <SvgStar />
+          <SvgHeart />
         </IconButton>{" "}
         {props.value}
-      </div>
+      </strong>
     ),
+    ITwinName: (props) => <i style={{ color: "red" }}>{props.value}</i>,
   },
 };
 

--- a/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
@@ -9,10 +9,12 @@ import {
   ITwinGrid as ExternalComponent,
   ITwinGridProps,
 } from "@itwin/imodel-browser-react";
+import { SvgStar } from "@itwin/itwinui-icons-react";
 import {
   Button,
   Code,
   DropdownButton,
+  IconButton,
   MenuItem,
   MenuItemSkeleton,
   Text,
@@ -48,6 +50,29 @@ const Template: Story<ITwinGridProps> = withAccessTokenOverride((args) => (
 export const Primary = Template.bind({});
 Primary.args = {
   apiOverrides: { serverEnvironmentPrefix: "qa" },
+};
+
+export const OverrideCellData = Template.bind({});
+OverrideCellData.args = {
+  apiOverrides: { serverEnvironmentPrefix: "qa" },
+  viewMode: "cells",
+  cellOverrides: {
+    ITwinNumber: (props) => (
+      <div>
+        <IconButton
+          size="small"
+          styleType="borderless"
+          onClick={(e) => {
+            e.stopPropagation();
+            console.log("Icon Clicked");
+          }}
+        >
+          <SvgStar />
+        </IconButton>{" "}
+        {props.value}
+      </div>
+    ),
+  },
 };
 
 export const OverrideApiData = Template.bind({});

--- a/packages/modules/imodel-browser/package.json
+++ b/packages/modules/imodel-browser/package.json
@@ -40,6 +40,7 @@
     "@rollup/plugin-commonjs": "~17.1.0",
     "@rollup/plugin-url": "^8.0.1",
     "@svgr/rollup": "^5.5.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^11.1.0",
     "@testing-library/react-hooks": "^5.1.0",
     "@types/jest": "^27.5.1",

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -13,6 +13,7 @@ import { NoResults } from "../../components/noResults/NoResults";
 import {
   ApiOverrides,
   DataStatus,
+  ITwinCellOverrides,
   ITwinFilterOptions,
   ITwinFull,
   ITwinSubClass,
@@ -97,6 +98,8 @@ export interface ITwinGridProps {
   ) => ITwinFull[];
   /**iTwin view mode */
   viewMode?: ViewType;
+  /** Overrides for cell rendering in cells viewMode */
+  cellOverrides?: ITwinCellOverrides;
 }
 
 /**
@@ -115,6 +118,7 @@ export const ITwinGrid = ({
   useIndividualState,
   postProcessCallback,
   viewMode,
+  cellOverrides,
 }: ITwinGridProps) => {
   const {
     iTwinFavorites,
@@ -170,6 +174,7 @@ export const ITwinGrid = ({
     addITwinToFavorites,
     removeITwinFromFavorites,
     refetchITwins,
+    cellOverrides,
   });
 
   const noResultsText = {

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -172,7 +172,9 @@ export const ITwinTile = ({
           {metadata && <Tile.Metadata>{metadata}</Tile.Metadata>}
           {children}
           {(moreOptions || moreOptionsBuilt) && (
-            <Tile.MoreOptions>
+            <Tile.MoreOptions
+              data-testid={`iTwin-tile-${iTwin.id}-more-options`}
+            >
               {moreOptions ?? moreOptionsBuilt}
             </Tile.MoreOptions>
           )}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import { useMemo } from "react";
 import { CellProps } from "react-table";
 
-import { ITwinFull } from "../../types";
+import { ITwinCellOverrides, ITwinFull } from "../../types";
 import {
   _buildManagedContextMenuOptions,
   ContextMenuBuilderItem,
@@ -23,6 +23,7 @@ export interface useITwinTableConfigProps {
   addITwinToFavorites: (iTwinId: string) => Promise<void>;
   removeITwinFromFavorites: (iTwinId: string) => Promise<void>;
   refetchITwins: () => void;
+  cellOverrides?: ITwinCellOverrides;
 }
 
 export const useITwinTableConfig = ({
@@ -33,6 +34,7 @@ export const useITwinTableConfig = ({
   addITwinToFavorites,
   removeITwinFromFavorites,
   refetchITwins,
+  cellOverrides = {},
 }: useITwinTableConfigProps) => {
   const onRowClick = (_: React.MouseEvent, row: any) => {
     const iTwin = row.original as ITwinFull;
@@ -84,7 +86,11 @@ export const useITwinTableConfig = ({
                 data-tip={props.row.original.number}
                 className="iac-iTwinCell"
               >
-                <span>{props.value}</span>
+                {cellOverrides.ITwinNumber ? (
+                  cellOverrides.ITwinNumber(props)
+                ) : (
+                  <span>{props.value}</span>
+                )}
               </div>
             ),
           },
@@ -92,6 +98,19 @@ export const useITwinTableConfig = ({
             id: "ITwinName",
             Header: strings.tableColumnDescription,
             accessor: "displayName",
+            maxWidth: 350,
+            Cell: (props: CellProps<ITwinFull>) => (
+              <div
+                data-tip={props.row.original.displayName}
+                className="iac-iTwinCell"
+              >
+                {cellOverrides.ITwinName ? (
+                  cellOverrides.ITwinName(props)
+                ) : (
+                  <span>{props.value}</span>
+                )}
+              </div>
+            ),
           },
           {
             id: "LastModified",
@@ -100,7 +119,11 @@ export const useITwinTableConfig = ({
             maxWidth: 350,
             Cell: (props: CellProps<ITwinFull>) => {
               const date = props.data[props.row.index].createdDateTime;
-              return date ? new Date(date).toDateString() : "";
+              return cellOverrides.LastModified
+                ? cellOverrides.LastModified(props)
+                : date
+                ? new Date(date).toDateString()
+                : "";
             },
           },
           {
@@ -138,16 +161,17 @@ export const useITwinTableConfig = ({
       },
     ],
     [
-      addITwinToFavorites,
-      iTwinActions,
-      iTwinFavorites,
-      removeITwinFromFavorites,
+      strings.tableColumnFavorites,
+      strings.tableColumnName,
+      strings.tableColumnDescription,
+      strings.tableColumnLastModified,
       strings.addToFavorites,
       strings.removeFromFavorites,
-      strings.tableColumnDescription,
-      strings.tableColumnFavorites,
-      strings.tableColumnLastModified,
-      strings.tableColumnName,
+      iTwinFavorites,
+      removeITwinFromFavorites,
+      addITwinToFavorites,
+      cellOverrides,
+      iTwinActions,
       refetchITwins,
     ]
   );

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinTableConfig.tsx
@@ -144,6 +144,7 @@ export const useITwinTableConfig = ({
               return iTwinActions && iTwinActions.length > 0 ? (
                 <DropdownMenu menuItems={moreOptions}>
                   <IconButton
+                    data-testid={`iTwin-row-${props.row.original.id}-more-options`}
                     styleType="borderless"
                     aria-label="More options"
                     className="iac-options-icon"

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
@@ -17,11 +17,13 @@ describe("IModelGrid", () => {
         {
           id: "iModel1",
           name: "Test IModel",
+          displayName: "Test IModel",
           description: "This is a test iModel",
         },
         {
           id: "iModel2",
           name: "Test IModel 2",
+          displayName: "Test IModel 2",
           description: "This is another test iModel",
         },
       ],
@@ -120,7 +122,7 @@ describe("IModelGrid", () => {
     expect(onClick).toHaveBeenCalled();
     expect(onThumbnailClick).not.toHaveBeenCalled();
   });
-  it("shoudl call onThumbnailClick when button doesn't have stopPropagation", () => {
+  it("should call onThumbnailClick when button doesn't have stopPropagation", () => {
     const onClick = jest.fn();
     const onThumbnailClick = jest.fn();
     const cellOverrides: IModelCellOverrides = {
@@ -152,7 +154,35 @@ describe("IModelGrid", () => {
     expect(onThumbnailClick).toHaveBeenCalledWith({
       id: "iModel1",
       name: "Test IModel",
+      displayName: "Test IModel",
       description: "This is a test iModel",
     });
+  });
+  it("should have more options when iModelActions are provided in cells view", () => {
+    const iModelActions = [
+      {
+        key: "action1",
+        label: "Action 1",
+        onClick: jest.fn(),
+      },
+      {
+        key: "action2",
+        label: "Action 2",
+        onClick: jest.fn(),
+      },
+    ];
+
+    const { getByTestId, queryAllByRole } = render(
+      <IModelGrid viewMode="cells" iModelActions={iModelActions} />
+    );
+
+    const optionsButton = getByTestId("iModel-row-Test IModel-more-options");
+    expect(optionsButton).toBeDefined();
+    let menuItems = queryAllByRole("menuitem");
+    expect(menuItems.length).toBe(0);
+    optionsButton.click();
+    // the dropdown should open and show the actions label Action 1 and Action 2
+    menuItems = queryAllByRole("menuitem");
+    expect(menuItems.length).toBe(2); // Action 1 and Action 2
   });
 });

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import "@testing-library/jest-dom";
+
+import { render } from "@testing-library/react";
+import React from "react";
+
+import { DataStatus, IModelCellOverrides, IModelGrid } from "../..";
+import * as useIModelData from "./useIModelData";
+
+describe("IModelGrid", () => {
+  beforeEach(() => {
+    jest.spyOn(useIModelData, "useIModelData").mockReturnValue({
+      iModels: [
+        {
+          id: "iModel1",
+          name: "Test IModel",
+          description: "This is a test iModel",
+        },
+        {
+          id: "iModel2",
+          name: "Test IModel 2",
+          description: "This is another test iModel",
+        },
+      ],
+      status: DataStatus.Complete,
+      fetchMore: undefined,
+      refetchIModels: jest.fn(),
+    });
+  });
+  it("renders without crashing", () => {
+    const wrapper = render(<IModelGrid viewMode="cells" />);
+    expect(wrapper).toBeDefined();
+  });
+  it("should display normal name and description", () => {
+    const { getByText } = render(<IModelGrid viewMode="cells" />);
+    expect(getByText("Test IModel")).toBeDefined();
+    expect(getByText("This is a test iModel")).toBeDefined();
+  });
+  it("should apply custom cell overrides", () => {
+    const cellOverrides: IModelCellOverrides = {
+      name: (props) => <strong>{props.value} 2</strong>,
+      description: (props) => <em>{props.value} 3</em>,
+    };
+    const { getByText } = render(
+      <IModelGrid viewMode="cells" cellOverrides={cellOverrides} />
+    );
+    expect(getByText("Test IModel 2")).toHaveStyle("font-weight: bold");
+    expect(getByText("This is a test iModel 3")).toHaveStyle(
+      "font-style: italic"
+    );
+  });
+  it("should handle empty data correctly", () => {
+    jest.spyOn(useIModelData, "useIModelData").mockReturnValue({
+      iModels: [],
+      status: DataStatus.Complete,
+      fetchMore: undefined,
+      refetchIModels: jest.fn(),
+    });
+
+    const wrapper = render(<IModelGrid viewMode="cells" />);
+    expect(
+      wrapper.getByText("There are no iModels in this iTwin.")
+    ).toBeDefined();
+  });
+  it("should display overwritten empty message", () => {
+    jest.spyOn(useIModelData, "useIModelData").mockReturnValue({
+      iModels: [],
+      status: DataStatus.Complete,
+      fetchMore: undefined,
+      refetchIModels: jest.fn(),
+    });
+
+    const { getByText } = render(
+      <IModelGrid
+        viewMode="cells"
+        stringsOverrides={{
+          noIModels: "No iModels available",
+        }}
+      />
+    );
+    expect(getByText("No iModels available")).toBeDefined();
+  });
+  it("should display the table and correct rows", () => {
+    const wrapper = render(<IModelGrid viewMode="cells" />);
+    expect(wrapper.getByRole("table")).toBeDefined();
+    expect(wrapper.getAllByRole("row").length).toEqual(3); // Header row + 2 data rows
+  });
+});

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
@@ -88,4 +88,71 @@ describe("IModelGrid", () => {
     expect(wrapper.getByRole("table")).toBeDefined();
     expect(wrapper.getAllByRole("row").length).toEqual(3); // Header row + 2 data rows
   });
+  it("should prevent onThumbnailClick from being called when button in cell is clicked with stopPropagation", () => {
+    const onClick = jest.fn();
+    const onThumbnailClick = jest.fn();
+    const cellOverrides: IModelCellOverrides = {
+      name: (props) => (
+        <div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onClick();
+            }}
+          >
+            Click Me
+          </button>
+          {props.value}
+        </div>
+      ),
+    };
+
+    const { getAllByText } = render(
+      <IModelGrid
+        viewMode="cells"
+        cellOverrides={cellOverrides}
+        onThumbnailClick={onThumbnailClick}
+      />
+    );
+
+    const buttons = getAllByText("Click Me");
+    buttons[0].click();
+    expect(onClick).toHaveBeenCalled();
+    expect(onThumbnailClick).not.toHaveBeenCalled();
+  });
+  it("shoudl call onThumbnailClick when button doesn't have stopPropagation", () => {
+    const onClick = jest.fn();
+    const onThumbnailClick = jest.fn();
+    const cellOverrides: IModelCellOverrides = {
+      name: (props) => (
+        <div>
+          <button
+            onClick={() => {
+              onClick();
+            }}
+          >
+            Click Me
+          </button>
+          {props.value}
+        </div>
+      ),
+    };
+
+    const { getAllByText } = render(
+      <IModelGrid
+        viewMode="cells"
+        cellOverrides={cellOverrides}
+        onThumbnailClick={onThumbnailClick}
+      />
+    );
+
+    const buttons = getAllByText("Click Me");
+    buttons[0].click();
+    expect(onClick).toHaveBeenCalled();
+    expect(onThumbnailClick).toHaveBeenCalledWith({
+      id: "iModel1",
+      name: "Test IModel",
+      description: "This is a test iModel",
+    });
+  });
 });

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.test.tsx
@@ -176,7 +176,7 @@ describe("IModelGrid", () => {
       <IModelGrid viewMode="cells" iModelActions={iModelActions} />
     );
 
-    const optionsButton = getByTestId("iModel-row-Test IModel-more-options");
+    const optionsButton = getByTestId("iModel-row-iModel1-more-options");
     expect(optionsButton).toBeDefined();
     let menuItems = queryAllByRole("menuitem");
     expect(menuItems.length).toBe(0);

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -11,6 +11,7 @@ import { NoResults } from "../../components/noResults/NoResults";
 import {
   ApiOverrides,
   DataStatus,
+  IModelCellOverrides,
   IModelFull,
   IModelSortOptions,
   ViewType,
@@ -88,6 +89,8 @@ export interface IModelGridProps {
   pageSize?: number;
   /** Maximum number of iModels to fetch, default is unlimited */
   maxCount?: number;
+  /** Overrides for cell rendering in cells viewMode */
+  cellOverrides?: IModelCellOverrides;
 }
 
 /**
@@ -109,6 +112,7 @@ export const IModelGrid = ({
   viewMode,
   pageSize,
   maxCount,
+  cellOverrides,
 }: IModelGridProps) => {
   const [sort, setSort] = React.useState<IModelSortOptions>(sortOptions);
   const [isSortOnTable, setIsSortOnTable] = React.useState(false);
@@ -174,6 +178,7 @@ export const IModelGrid = ({
     onThumbnailClick,
     strings,
     refetchIModels,
+    cellOverrides,
   });
 
   const noResultsText = {

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import { useMemo } from "react";
 import { CellProps } from "react-table";
 
-import { IModelFull } from "../../types";
+import { IModelCellOverrides, IModelFull } from "../../types";
 import {
   _buildManagedContextMenuOptions,
   ContextMenuBuilderItem,
@@ -28,6 +28,7 @@ export interface useIModelTableConfigProps {
     error: string;
   };
   refetchIModels: () => void;
+  cellOverrides?: IModelCellOverrides;
 }
 
 export const useIModelTableConfig = ({
@@ -35,6 +36,7 @@ export const useIModelTableConfig = ({
   onThumbnailClick,
   strings,
   refetchIModels,
+  cellOverrides = {},
 }: useIModelTableConfigProps) => {
   const onRowClick = (_: React.MouseEvent, row: any) => {
     const iModel = row.original as IModelFull;
@@ -56,7 +58,9 @@ export const useIModelTableConfig = ({
             maxWidth: 350,
             Cell: (props: CellProps<IModelFull>) => (
               <div data-tip={props.row.original.name}>
-                <span>{props.value}</span>
+                <span>
+                  {cellOverrides.name ? cellOverrides.name(props) : props.value}
+                </span>
               </div>
             ),
           },
@@ -65,6 +69,15 @@ export const useIModelTableConfig = ({
             Header: strings.tableColumnDescription,
             accessor: "description",
             disableSortBy: true,
+            Cell: (props: CellProps<IModelFull>) => (
+              <div data-tip={props.row.original.description}>
+                <span>
+                  {cellOverrides.description
+                    ? cellOverrides.description(props)
+                    : props.value}
+                </span>
+              </div>
+            ),
           },
           {
             id: "createdDateTime",
@@ -73,7 +86,11 @@ export const useIModelTableConfig = ({
             maxWidth: 350,
             Cell: (props: CellProps<IModelFull>) => {
               const date = props.data[props.row.index].createdDateTime;
-              return date ? new Date(date).toDateString() : "";
+              return cellOverrides.createdDateTime
+                ? cellOverrides.createdDateTime(props)
+                : date
+                ? new Date(date).toDateString()
+                : "";
             },
           },
           {
@@ -116,10 +133,11 @@ export const useIModelTableConfig = ({
       },
     ],
     [
-      iModelActions,
+      strings.tableColumnName,
       strings.tableColumnDescription,
       strings.tableColumnLastModified,
-      strings.tableColumnName,
+      cellOverrides,
+      iModelActions,
       refetchIModels,
     ]
   );

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelTableConfig.tsx
@@ -116,6 +116,7 @@ export const useIModelTableConfig = ({
                   }}
                 >
                   <IconButton
+                    data-testid={`iModel-row-${props.row.original.id}-more-options`}
                     styleType="borderless"
                     aria-label="More options"
                     className="iac-options-icon"

--- a/packages/modules/imodel-browser/src/types.ts
+++ b/packages/modules/imodel-browser/src/types.ts
@@ -99,8 +99,14 @@ export type ViewType = "tile" | "cells";
 // Remove this IModelViewType with next major release i.e 2.0
 export type IModelViewType = ViewType;
 
-export type CellOverrides = {
+export type IModelCellOverrides = {
   name?: (cellData: CellProps<IModelFull>) => React.ReactNode;
   description?: (cellData: CellProps<IModelFull>) => React.ReactNode;
   createdDateTime?: (cellData: CellProps<IModelFull>) => React.ReactNode;
+};
+
+export type ITwinCellOverrides = {
+  ITwinNumber?: (cellData: CellProps<ITwinFull>) => React.ReactNode;
+  ITwinName?: (cellData: CellProps<ITwinFull>) => React.ReactNode;
+  LastModified?: (cellData: CellProps<ITwinFull>) => React.ReactNode;
 };

--- a/packages/modules/imodel-browser/src/types.ts
+++ b/packages/modules/imodel-browser/src/types.ts
@@ -2,6 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
+import { CellProps } from "react-table";
+
 /** Full representation of the iModel. */
 export interface IModelFull {
   /** "Globally Unique Identifier of the iModel" */
@@ -95,3 +98,9 @@ export type ITwinStatus =
 export type ViewType = "tile" | "cells";
 // Remove this IModelViewType with next major release i.e 2.0
 export type IModelViewType = ViewType;
+
+export type CellOverrides = {
+  name?: (cellData: CellProps<IModelFull>) => React.ReactNode;
+  description?: (cellData: CellProps<IModelFull>) => React.ReactNode;
+  createdDateTime?: (cellData: CellProps<IModelFull>) => React.ReactNode;
+};


### PR DESCRIPTION
Add ability to provide a custom component for each cell of the iModel/iTwin Grid
Added tests and stories for each.
iTwin Grid
<img width="881" height="513" alt="image" src="https://github.com/user-attachments/assets/2cf11744-25c8-4b56-a8be-8b3cfe117178" />
iModel Grid
<img width="882" height="602" alt="image" src="https://github.com/user-attachments/assets/c751d9f0-ccaa-41ce-b81a-a7a1a7ce54af" />
