### PR TITLE
Added hide version option for manage versions with hidden icon

### DIFF
--- a/common/changes/@itwin/manage-versions-react/vp-hide-version-feature_2025-06-09-13-26.json
+++ b/common/changes/@itwin/manage-versions-react/vp-hide-version-feature_2025-06-09-13-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "Added hide version option for manage versions",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react"
+}

--- a/packages/modules/manage-versions/src/clients/namedVersionClient.ts
+++ b/packages/modules/manage-versions/src/clients/namedVersionClient.ts
@@ -61,7 +61,7 @@ export class NamedVersionClient {
   public async update(
     imodelId: string,
     versionId: string,
-    version: { name: string; description: string }
+    version: { name: string; description: string; state?: string }
   ): Promise<NamedVersion> {
     return this._http
       .patch(

--- a/packages/modules/manage-versions/src/common/configContext.tsx
+++ b/packages/modules/manage-versions/src/common/configContext.tsx
@@ -17,6 +17,7 @@ const ConfigContext = React.createContext<
       imodelId: string;
       stringsOverrides: ManageVersionsStringOverrides;
       log?: LogFunc;
+      enableHideVersions: boolean;
     }
   | undefined
 >(undefined);
@@ -28,6 +29,7 @@ export type ConfigProviderProps = {
   stringsOverrides: ManageVersionsStringOverrides;
   log?: LogFunc;
   children: React.ReactNode;
+  enableHideVersions: boolean;
 };
 
 export const ConfigProvider = (props: ConfigProviderProps) => {

--- a/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ChangesTab/ChangesTab.tsx
@@ -9,8 +9,8 @@ import {
   SvgNamedVersionAdd,
 } from "@itwin/itwinui-icons-react";
 import { IconButton, Table, Text } from "@itwin/itwinui-react";
+import { CellProps } from "@itwin/itwinui-react/react-table";
 import React from "react";
-import { CellProps } from "react-table";
 
 import { useConfig } from "../../../common/configContext";
 import {

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.scss
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.scss
@@ -8,3 +8,7 @@
     word-break: break-word;
   }
 }
+
+.iac-label-show-hidden-versions {
+  width: max-content;
+}

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.test.tsx
@@ -44,6 +44,8 @@ const renderComponent = (initialProps?: Partial<VersionsTabProps>) => {
     tableData: MockedVersionTableData(),
     changesetClient: new ChangesetClient("token"),
     setRelatedChangesets: jest.fn(),
+    handleHideVersion: jest.fn(),
+    showHiddenVersions: false,
     ...initialProps,
   };
   return render(
@@ -64,17 +66,22 @@ describe("VersionsTab", () => {
 
     rows.forEach(async (row) => {
       const cells = row.querySelectorAll("div[role='cell']");
-      expect(cells.length).toBe(6);
-      expect(cells[0].textContent).toContain(MockedVersion().name);
-      expect(cells[1].textContent).toContain(MockedVersion().description);
-      expect(cells[2].textContent).toContain(MockedVersion().createdBy);
-      expect(cells[3].textContent).toContain(MockedVersion().createdDateTime);
-      expect(cells[4].textContent).toContain(defaultStrings.view);
+      expect(cells.length).toBe(7);
+      expect(cells[0].textContent).toContain("");
+      expect(cells[1].textContent).toContain(MockedVersion().name);
+      expect(cells[2].textContent).toContain(MockedVersion().description);
+      expect(cells[3].textContent).toContain(MockedVersion().createdBy);
+      expect(cells[4].textContent).toContain(MockedVersion().createdDateTime);
+      expect(cells[5].textContent).toContain(defaultStrings.view);
       const viewSpan = screen.getByText("View");
       await act(() => fireEvent.click(viewSpan));
-      const actionButton = within(cells[5] as HTMLElement).getByRole("button", {
-        name: "More",
-      });
+      const actionsCell = cells[cells.length - 1];
+      const actionButton = within(actionsCell as HTMLElement).getByRole(
+        "button",
+        {
+          name: "More",
+        }
+      );
       expect(actionButton).toBeTruthy();
       await act(() => fireEvent.click(actionButton));
       const updateAction = await screen.findByText(
@@ -83,6 +90,10 @@ describe("VersionsTab", () => {
       if (defaultStrings.download) {
         const downloadAction = screen.getByText(defaultStrings.download);
         expect(downloadAction).toBeTruthy();
+      }
+      if (defaultStrings.hide) {
+        const hideAction = screen.getByText(defaultStrings.hide);
+        expect(hideAction).toBeTruthy();
       }
       expect(updateAction).toBeTruthy();
     });
@@ -147,13 +158,15 @@ describe("VersionsTab", () => {
 
     rowsOnExpand.forEach(async (row, index) => {
       const cells = row.querySelectorAll('[role="cell"]');
-      expect(cells.length).toBe(6);
+      expect(cells.length).toBe(7);
       if (index === 0) {
-        expect(cells[0].textContent).toContain(MockedVersion().name);
-        expect(cells[1].textContent).toContain(MockedVersion().description);
-        expect(cells[2].textContent).toContain(MockedVersion().createdBy);
-        expect(cells[3].textContent).toContain(MockedVersion().createdDateTime);
-        expect(cells[4].textContent).toContain(defaultStrings.view);
+        expect(cells[0].textContent).toContain("");
+        expect(cells[1].textContent).toContain(MockedVersion().name);
+        expect(cells[2].textContent).toContain(MockedVersion().description);
+        expect(cells[3].textContent).toContain(MockedVersion().createdBy);
+        expect(cells[4].textContent).toContain(MockedVersion().createdDateTime);
+        expect(cells[5].textContent).toContain(defaultStrings.view);
+
         const viewSpan = screen.getByText("View");
         await act(() => fireEvent.click(viewSpan));
         const actionsCell = cells[cells.length - 1];
@@ -169,19 +182,19 @@ describe("VersionsTab", () => {
           expect(updateAction).toBeTruthy();
         }
       } else {
-        expect(cells[0].textContent).toContain(
+        expect(cells[1].textContent).toContain(
           MockedChangeset(index).displayName
         );
-        expect(cells[1].textContent).toContain(
+        expect(cells[2].textContent).toContain(
           MockedChangeset(index).description
         );
-        expect(cells[2].textContent).toContain(
+        expect(cells[3].textContent).toContain(
           MockedChangeset(index).createdBy
         );
-        expect(cells[3].textContent).toContain(
+        expect(cells[4].textContent).toContain(
           MockedChangeset(index).pushDateTime
         );
-        expect(cells[4].textContent).not.toContain(defaultStrings.view);
+        expect(cells[5].textContent).not.toContain(defaultStrings.view);
         const actionsCell = cells[cells.length - 1];
         expect(actionsCell.children.length).toBe(0);
       }

--- a/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/VersionsTab/VersionsTab.tsx
@@ -234,7 +234,6 @@ const VersionsTab = (props: VersionsTabProps) => {
         columns: [
           {
             id: "HIDDEN",
-            accessor: "Hidden",
             width: 80,
             Cell: (props: CellProps<VersionTableData>) => {
               const version = props.row.original;

--- a/packages/modules/manage-versions/src/components/ManageVersions/types.ts
+++ b/packages/modules/manage-versions/src/components/ManageVersions/types.ts
@@ -33,7 +33,11 @@ export type ManageVersionsStringOverrides = {
   /** Default: `Update` */
   update: string;
   /** Default: `Download` */
-  download?: string;
+  download: string;
+  /** Default: `Hide` */
+  hide: string;
+  /** Default: `Unhide` */
+  unhide: string;
   /** Label for Named Version context menu` Default `More` */
   More?: string;
   /** Default: `View` */
@@ -72,6 +76,18 @@ export type ManageVersionsStringOverrides = {
   informationPanel?: string;
   /** string overrides for text within Information panel` */
   informationPanelStringOverrides?: InformationPanelStringOverrides;
+  /** Default: `Show hidden Versions` */
+  messageShowHiddenVersions: string;
+  /** Default: Named Version "{{versionName}}" was successfully hidden.*/
+  messageHideVersionSucess: string;
+  /** Default: Named Version "{{versionName}}" was successfully unhidden.*/
+  messageUnhideVersionSucess: string;
+  /** Default: `Could not hide Named Version. Please try again later. */
+  messageHideVersionFailed: string;
+  /** Default: `Could not unhide Named Version. Please try again later. */
+  messageUnhideVersionFailed: string;
+  /** Default: `Hidden` */
+  hidden: string;
 };
 
 export type LogFunc = (

--- a/packages/modules/manage-versions/src/mocks.ts
+++ b/packages/modules/manage-versions/src/mocks.ts
@@ -15,6 +15,7 @@ export const MOCKED_CONFIG_PROPS = {
   accessToken: "Bearer test",
   imodelId: MOCKED_IMODEL_ID,
   stringsOverrides: defaultStrings,
+  enableHideVersions: true,
 } as ConfigProviderProps;
 
 export const MockedVersion = (
@@ -27,6 +28,7 @@ export const MockedVersion = (
     name: `nv_name${index}`,
     description: `nv_description${index}`,
     createdDateTime: MOCKED_DATE,
+    state: `visible`,
     _links: {
       changeSet: {
         href: "https://someChangesetUrl.com",

--- a/packages/modules/manage-versions/src/models/namedVersion.ts
+++ b/packages/modules/manage-versions/src/models/namedVersion.ts
@@ -10,6 +10,7 @@ export type NamedVersionBackend = {
   name: string;
   description: string;
   createdDateTime: string;
+  state: string;
   _links: {
     changeSet: {
       href: string;


### PR DESCRIPTION
Changes :-
Hide Version feature:- User can directly hide or unhide an named version from the UI. Initially all the unhidden versions are displayed and after toggle switch user can able to see all the named version. The toggle switch is provided to show hidden versions.

Note :-
enableHideVersions Prop :- This prop is added to manageVersionProps to enable the feature.
The dependency on @types/react-table has been removed according to itwinui V3 Migration.

Show Hidden Version:
<img width="2506" height="628" alt="image" src="https://github.com/user-attachments/assets/af54d789-71ba-46ae-8412-c8b5ac67c439" />

<img width="2242" height="495" alt="image" src="https://github.com/user-attachments/assets/e63c0b52-d619-4c85-8458-e8dd83d28f1d" />
Hide Hidden Version:
<img width="2247" height="297" alt="image" src="https://github.com/user-attachments/assets/2f652e7d-7461-4774-8bf5-6f71fcd96165" />

Disable Hidden Version feature
<img width="2255" height="1187" alt="image" src="https://github.com/user-attachments/assets/12711543-535b-4c25-afde-f3391f76c6a7" />
