### PR TITLE
Show Tile Metadata if provided as tileprops

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/show-metadata_2025-07-23-10-05.json
+++ b/common/changes/@itwin/imodel-browser-react/show-metadata_2025-07-23-10-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Show Tile Metadata if provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -169,7 +169,11 @@ export const ITwinTile = ({
           <Tile.Description>
             {description ?? iTwin.number ?? ""}
           </Tile.Description>
-          {metadata && <Tile.Metadata>{metadata}</Tile.Metadata>}
+          {metadata && (
+            <Tile.Metadata data-testid={`iTwin-tile-${iTwin.id}-metadata`}>
+              {metadata}
+            </Tile.Metadata>
+          )}
           {children}
           {(moreOptions || moreOptionsBuilt) && (
             <Tile.MoreOptions

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.test.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.test.tsx
@@ -62,4 +62,18 @@ describe("IModelTile", () => {
     name.click();
     expect(onThumbnailClick).toHaveBeenCalledWith(iModel);
   });
+  it("should display metadata if provided", () => {
+    const { getByTestId } = render(
+      <IModelTile
+        iModel={iModel}
+        tileProps={{
+          metadata: <div>New iModel Metadata</div>,
+        }}
+      />
+    );
+
+    // check if metadata is displayed
+    const metadata = getByTestId(`iModel-tile-${iModel.id}-metadata`);
+    expect(metadata).toBeInTheDocument();
+  });
 });

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -60,6 +60,7 @@ export const IModelTile = ({
     moreOptions,
     isDisabled,
     onClick,
+    metadata,
     ...rest
   } = tileProps ?? {};
 
@@ -133,6 +134,11 @@ export const IModelTile = ({
           >
             {moreOptions ?? moreOptionsBuilt}
           </Tile.MoreOptions>
+        )}
+        {metadata && (
+          <Tile.Metadata data-testid={`iModel-tile-${iModel.id}-metadata`}>
+            {metadata}
+          </Tile.Metadata>
         )}
       </Tile.ContentArea>
       {buttons && <Tile.Buttons>{buttons}</Tile.Buttons>}


### PR DESCRIPTION
This PR fixes a bug, as Tile Metadata was missing even if consumer provided it.

References: [iTwinUI Story](https://itwin.github.io/iTwinUI/react/?source=true&story=tile--all-props&theme=dark#ladle_loc_63)