### PR TITLE
Fix iModelGrid Filtering via postProcessCallback to Show Complete Results Across All Data

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/vp-fix-filtering-issue_2025-09-17-09-16.json
+++ b/common/changes/@itwin/imodel-browser-react/vp-fix-filtering-issue_2025-09-17-09-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Fix iModelGrid Filtering via postProcessCallback to Show Complete Results Across All Data",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -20,7 +20,7 @@ import { _mergeStrings } from "../../utils/_apiOverrides";
 import { ContextMenuBuilderItem } from "../../utils/_buildMenuOptions";
 import { IModelGhostTile } from "../iModelTiles/IModelGhostTile";
 import { IModelTile, IModelTileProps } from "../iModelTiles/IModelTile";
-import { useIModelData } from "./useIModelData";
+import { DEFAULT_PAGE_SIZE, useIModelData } from "./useIModelData";
 import { useIModelTableConfig } from "./useIModelTableConfig";
 export interface IModelGridProps {
   /**
@@ -172,6 +172,16 @@ export const IModelGrid = ({
       fetchediModels,
     [postProcessCallback, fetchediModels, fetchStatus, searchText]
   );
+
+  React.useEffect(() => {
+    if (
+      iModels.length < (pageSize ?? DEFAULT_PAGE_SIZE) &&
+      fetchMore &&
+      fetchStatus !== DataStatus.Fetching
+    ) {
+      fetchMore();
+    }
+  }, [iModels.length, pageSize, fetchMore, fetchStatus]);
 
   const { columns, onRowClick } = useIModelTableConfig({
     iModelActions,

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/useIModelData.ts
@@ -25,7 +25,7 @@ export interface IModelDataHookOptions {
   /** @deprecated in 2.1 It is no longer used as it has no effect on the data fetching. */
   viewMode?: ViewType;
 }
-const DEFAULT_PAGE_SIZE = 100;
+export const DEFAULT_PAGE_SIZE = 100;
 
 export const useIModelData = ({
   iTwinId,


### PR DESCRIPTION
This PR fixes two critical issues with the IModelGrid component's handling of client-side filtering via postProcessCallback:

**1) Incomplete Results**:  The component was only filtering against the first batch of data and not searching subsequent batches

**2) Premature "No Results"**:  When no matches were found in the first batch, it incorrectly displayed "No iModels" even when matches existed in later batches

Problem Details
When we applied filtering via postProcessCallback (e.g., filtering by description or name of iModel) :

If matching iModels existed in both 1st batch of iModels and later batches, only the early matches would be shown
If no matches existed in the first batch but did exist in later batches, we get "No iModels"

With new changes This useEffect ensures that when filtering results in few or no matches from the current batch, the component will:
- Continue loading additional batches of data
- Check those batches against the filter criteria
