### PR TITLE
Feat: Prop to make tiles take full width of column

### DIFF
--- a/packages/modules/imodel-browser/src/components/gridStructure/GridStructure.scss
+++ b/packages/modules/imodel-browser/src/components/gridStructure/GridStructure.scss
@@ -10,11 +10,11 @@ $space-for-shadows: 3px;
   justify-content: space-between;
   grid-template-columns: repeat(auto-fill, minmax(288px, 1fr));
   grid-auto-rows: min-content;
-  margin: calc(22px - #{$space-for-shadows})
+  padding: calc(22px - #{$space-for-shadows})
     calc(#{$responsive-grid-margin} - #{$space-for-shadows});
   gap: $responsive-grid-gutter;
   overflow: hidden;
-  padding: $space-for-shadows;
+  margin: $space-for-shadows;
 
   > * {
     display: inline-flex;

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -202,9 +202,9 @@ export const ITwinGrid = ({
       <GridStructure>
         {fetchStatus === DataStatus.Fetching ? (
           <>
-            <IModelGhostTile />
-            <IModelGhostTile />
-            <IModelGhostTile />
+            <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
+            <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
+            <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
           </>
         ) : (
           <>
@@ -235,10 +235,10 @@ export const ITwinGrid = ({
             {fetchMore ? (
               <>
                 <InView onChange={fetchMore}>
-                  <IModelGhostTile />
+                  <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
                 </InView>
-                <IModelGhostTile />
-                <IModelGhostTile />
+                <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
+                <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
               </>
             ) : null}
           </>

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -108,6 +108,8 @@ export interface ITwinGridProps {
   viewMode?: ViewType;
   /** Overrides for cell rendering in cells viewMode */
   cellOverrides?: ITwinCellOverrides;
+  /** Additional class name for the grid structure */
+  className?: string;
 }
 
 /**
@@ -128,6 +130,7 @@ export const ITwinGrid = ({
   postProcessCallback,
   viewMode,
   cellOverrides,
+  className,
 }: ITwinGridProps) => {
   const {
     iTwinFavorites,
@@ -199,7 +202,7 @@ export const ITwinGrid = ({
     iTwins.length === 0 && noResultsText ? (
       <NoResults text={noResultsText} />
     ) : (
-      <GridStructure>
+      <GridStructure className={className}>
         {fetchStatus === DataStatus.Fetching ? (
           <>
             <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinTile.tsx
@@ -43,6 +43,8 @@ export interface ITwinTileProps {
   removeFromFavorites?(iTwinId: string): Promise<void>;
   /** Function to refetch iTwins */
   refetchITwins?: () => void;
+  /** Indicates whether the tile should take the full width of its container */
+  fullWidth?: boolean;
 }
 
 /**
@@ -58,6 +60,7 @@ export const ITwinTile = ({
   addToFavorites,
   removeFromFavorites,
   refetchITwins,
+  fullWidth,
 }: ITwinTileProps) => {
   const {
     name,
@@ -108,6 +111,7 @@ export const ITwinTile = ({
         isLoading={isLoading}
         status={status}
         isDisabled={isDisabled}
+        style={fullWidth ? { width: "100%" } : undefined}
         {...rest}
       >
         <Tile.Name>

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -228,14 +228,19 @@ export const IModelGrid = ({
                 }}
               >
                 {({ ref }) => {
-                  return <IModelGhostTile ref={ref} />;
+                  return (
+                    <IModelGhostTile
+                      ref={ref}
+                      fullWidth={tileOverrides?.fullWidth}
+                    />
+                  );
                 }}
               </InView>
             ) : null}
             {fetchStatus === DataStatus.Fetching && (
               <>
-                <IModelGhostTile />
-                <IModelGhostTile />
+                <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
+                <IModelGhostTile fullWidth={tileOverrides?.fullWidth} />
               </>
             )}
           </GridStructure>

--- a/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelGrid/IModelGrid.tsx
@@ -91,6 +91,8 @@ export interface IModelGridProps {
   maxCount?: number;
   /** Overrides for cell rendering in cells viewMode */
   cellOverrides?: IModelCellOverrides;
+  /** Additional class name for the grid structure */
+  className?: string;
 }
 
 /**
@@ -113,6 +115,7 @@ export const IModelGrid = ({
   pageSize,
   maxCount,
   cellOverrides,
+  className,
 }: IModelGridProps) => {
   const [sort, setSort] = React.useState<IModelSortOptions>(sortOptions);
   const [isSortOnTable, setIsSortOnTable] = React.useState(false);
@@ -207,7 +210,7 @@ export const IModelGrid = ({
     return (
       <>
         {viewMode !== "cells" ? (
-          <GridStructure>
+          <GridStructure className={className}>
             {iModels?.map((iModel) => (
               <IModelHookedTile
                 key={iModel.id}

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelGhostTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelGhostTile.tsx
@@ -5,29 +5,35 @@
 import { Text, ThemeProvider, Tile } from "@itwin/itwinui-react";
 import React, { forwardRef } from "react";
 
+interface IModelGhostTileProps {
+  fullWidth?: boolean;
+}
+
 /**
  * Representation of a Ghost IModel
  */
-export const IModelGhostTile = forwardRef<HTMLDivElement>((props, ref) => {
-  return (
-    <ThemeProvider ref={ref} theme="inherit" {...props}>
-      <Tile.Wrapper>
-        <Tile.ThumbnailArea>
-          <Text isSkeleton>Skeleton</Text>
-        </Tile.ThumbnailArea>
-        <Tile.Name>
-          <Text isSkeleton variant="leading">
-            Skeleton Name
-          </Text>
-        </Tile.Name>
-        <Tile.ContentArea>
-          <Tile.Description>
-            <Text isSkeleton variant="title">
-              Skeleton Description
+export const IModelGhostTile = forwardRef<HTMLDivElement, IModelGhostTileProps>(
+  ({ fullWidth, ...props }, ref) => {
+    return (
+      <ThemeProvider ref={ref} theme="inherit" {...props}>
+        <Tile.Wrapper style={fullWidth ? { width: "100%" } : undefined}>
+          <Tile.ThumbnailArea>
+            <Text isSkeleton>Skeleton</Text>
+          </Tile.ThumbnailArea>
+          <Tile.Name>
+            <Text isSkeleton variant="leading">
+              Skeleton Name
             </Text>
-          </Tile.Description>
-        </Tile.ContentArea>
-      </Tile.Wrapper>
-    </ThemeProvider>
-  );
-});
+          </Tile.Name>
+          <Tile.ContentArea>
+            <Tile.Description>
+              <Text isSkeleton variant="title">
+                Skeleton Description
+              </Text>
+            </Tile.Description>
+          </Tile.ContentArea>
+        </Tile.Wrapper>
+      </ThemeProvider>
+    );
+  }
+);

--- a/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
+++ b/packages/modules/imodel-browser/src/containers/iModelTiles/IModelTile.tsx
@@ -31,6 +31,8 @@ export interface IModelTileProps {
   apiOverrides?: ApiOverrides;
   /** Function to refetch iModels */
   refetchIModels?: () => void;
+  /** Indicates whether the tile should take the full width of its container */
+  fullWidth?: boolean;
 }
 
 /**
@@ -44,6 +46,7 @@ export const IModelTile = ({
   apiOverrides,
   tileProps,
   refetchIModels,
+  fullWidth = false,
 }: IModelTileProps) => {
   const {
     name,
@@ -90,6 +93,7 @@ export const IModelTile = ({
       isLoading={isLoading}
       status={status}
       isDisabled={isDisabled}
+      style={fullWidth ? { width: "100%" } : undefined}
       {...rest}
     >
       <Tile.Name>


### PR DESCRIPTION
1. Full width tiles
Full width on the tiles can already be achieved by adding a style/classname to the tileOverrides. The problem is that the loading tiles dont get the style applied so we end up with a situation like this 
![loading-tile-full-width](https://github.com/user-attachments/assets/c2abeaf7-6f36-4366-b194-9c8bc01846b3)
Adding the fullWidth prop ensure that both the tiles and loading tiles get the same width.

2. Added classname props to the iTwinGrid and iModelGrid, currently in codebases consuming this package, they were using .iac-grid-structure to target this component, we should instead expose the classname for better customization.

3. The tile shadow wasn't fully visible on hover
The padding was tight and margin was wide, I inverted them.
|  Before  |  After  |
|----|----|
|  hello  |  after  | 

| Before | After |
|----------|----------|
| ![shadow-before](https://github.com/user-attachments/assets/1008b4f9-5f0b-40c5-8c8e-92ea26026147) | ![shadow-after](https://github.com/user-attachments/assets/7f109c2f-c4c2-4269-b9b4-67d06077d24e) | 