### PR TITLE
Fix auth in github page

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -17,6 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Storybook auth client id
+        env:
+          STORYBOOK_AUTH_CLIENT_ID: ${{ secrets.STORYBOOK_AUTH_CLIENT_ID }}
+        run: |
+          if [ -z "$STORYBOOK_AUTH_CLIENT_ID" ]; then
+            echo "STORYBOOK_AUTH_CLIENT_ID is not set. Add it as a GitHub Actions secret."
+            exit 1
+          fi
+
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
@@ -30,6 +39,8 @@ jobs:
 
       - name: Build Storybook static
         working-directory: packages/apps/storybook
+        env:
+          STORYBOOK_AUTH_CLIENT_ID: ${{ secrets.STORYBOOK_AUTH_CLIENT_ID }}
         run: |
           set -e
           node ../../../common/scripts/install-run-rushx.js build-storybook


### PR DESCRIPTION
In order for the auth to work on the gh page, we need to add the client id to the secrets on the repo (STORYBOOK_AUTH_CLIENT_ID)
<img width="1152" height="782" alt="image" src="https://github.com/user-attachments/assets/218825bf-ddfd-4f28-a8c5-3696c5d01b60" />
We should also add https://itwin.github.io/admin-components-react/signin-oidc.html to the "Redirect URIs" in developer.bentley.com where the client id is generated.