### PR TITLE
Remove eslint-config-react-app

### DIFF
--- a/common/changes/@itwin/create-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/create-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/create-imodel-react",
       "comment": "",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "@itwin/create-imodel-react"

--- a/common/changes/@itwin/create-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/create-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/create-imodel-react",
-      "comment": "Remove eslint-config-react-app",
+      "comment": "",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/create-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/create-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/create-imodel-react",
+      "comment": "Remove eslint-config-react-app",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/create-imodel-react"
+}

--- a/common/changes/@itwin/delete-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/delete-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/delete-imodel-react",
-      "comment": "Remove eslint-config-react-app",
+      "comment": "",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/delete-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/delete-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/delete-imodel-react",
+      "comment": "Remove eslint-config-react-app",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/delete-imodel-react"
+}

--- a/common/changes/@itwin/delete-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/delete-imodel-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/delete-imodel-react",
       "comment": "",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "@itwin/delete-imodel-react"

--- a/common/changes/@itwin/delete-itwin-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/delete-itwin-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/delete-itwin-react",
+      "comment": "Remove eslint-config-react-app",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/delete-itwin-react"
+}

--- a/common/changes/@itwin/delete-itwin-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/delete-itwin-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/delete-itwin-react",
-      "comment": "Remove eslint-config-react-app",
+      "comment": "",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/delete-itwin-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/delete-itwin-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/delete-itwin-react",
       "comment": "",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "@itwin/delete-itwin-react"

--- a/common/changes/@itwin/imodel-browser-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/imodel-browser-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-browser-react",
-      "comment": "Remove eslint-config-react-app",
+      "comment": "",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/imodel-browser-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/imodel-browser-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/imodel-browser-react",
       "comment": "",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "@itwin/imodel-browser-react"

--- a/common/changes/@itwin/imodel-browser-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/imodel-browser-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Remove eslint-config-react-app",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/common/changes/@itwin/manage-versions-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/manage-versions-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/manage-versions-react",
       "comment": "",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "@itwin/manage-versions-react"

--- a/common/changes/@itwin/manage-versions-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/manage-versions-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "Remove eslint-config-react-app",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react"
+}

--- a/common/changes/@itwin/manage-versions-react/alex-eslint-cra_2026-05-15-16-23.json
+++ b/common/changes/@itwin/manage-versions-react/alex-eslint-cra_2026-05-15-16-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/manage-versions-react",
-      "comment": "Remove eslint-config-react-app",
+      "comment": "",
       "type": "patch"
     }
   ],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -47,8 +47,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -99,8 +97,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_eslint@8.57.1
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_zhzwbfsaog5y5ieb74tndwu2py
@@ -131,8 +127,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -169,8 +163,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_bw7kk2ci4knuncltf2ikoilu5e
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_ye2kgvhjayfeirdtxplgmjcwka
@@ -208,8 +200,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -246,8 +236,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_bw7kk2ci4knuncltf2ikoilu5e
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_ye2kgvhjayfeirdtxplgmjcwka
@@ -285,8 +273,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -323,8 +309,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_bw7kk2ci4knuncltf2ikoilu5e
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_ye2kgvhjayfeirdtxplgmjcwka
@@ -368,8 +352,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -422,8 +404,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_bw7kk2ci4knuncltf2ikoilu5e
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_ye2kgvhjayfeirdtxplgmjcwka
@@ -472,8 +452,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -513,8 +491,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_bw7kk2ci4knuncltf2ikoilu5e
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_ye2kgvhjayfeirdtxplgmjcwka
@@ -555,8 +531,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -586,8 +560,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_avq3eyf5kaj6ssrwo7fvkrwnji
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_zhzwbfsaog5y5ieb74tndwu2py
@@ -608,8 +580,6 @@ importers:
       eslint: ^8.3.0
       eslint-config-airbnb: ^0.0.4
       eslint-config-prettier: ^6.11.0
-      eslint-config-react-app: ^7.0.1
-      eslint-plugin-flowtype: ^5.2.0
       eslint-plugin-import: ^2.22.0
       eslint-plugin-jsx-a11y: ^6.3.1
       eslint-plugin-prettier: ^3.1.4
@@ -631,8 +601,6 @@ importers:
       eslint: 8.57.1
       eslint-config-airbnb: 0.0.4
       eslint-config-prettier: 6.15.0_eslint@8.57.1
-      eslint-config-react-app: 7.0.1_avq3eyf5kaj6ssrwo7fvkrwnji
-      eslint-plugin-flowtype: 5.10.0_eslint@8.57.1
       eslint-plugin-import: 2.31.0_eslint@8.57.1
       eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
       eslint-plugin-prettier: 3.4.1_ye2kgvhjayfeirdtxplgmjcwka
@@ -2740,20 +2708,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       tabbable: 6.2.0
-    dev: true
-
-  /@floating-ui/react/0.27.6_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-9GLOPbW8jTeboR2ar9uMMUDUZjpTLscUvOjNvRw2EgppgoLHLUh/P/OW9evULosnvDjhYf2Gwk/gMOP9KvXD2A==}
-    peerDependencies:
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
-    dependencies:
-      '@floating-ui/react-dom': 2.1.6_nnrd3gsncyragczmpvfhocinkq
-      '@floating-ui/utils': 0.2.10
-      react: 18.3.1
-      react-dom: 18.3.1_react@18.3.1
-      tabbable: 6.2.0
-    dev: false
 
   /@floating-ui/utils/0.2.10:
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
@@ -5324,12 +5278,6 @@ packages:
       - supports-color
     dev: true
 
-  /@swc/helpers/0.5.15:
-    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-    dependencies:
-      tslib: 2.8.1
-    dev: false
-
   /@swc/helpers/0.5.17:
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
     dependencies:
@@ -5344,26 +5292,9 @@ packages:
       '@tanstack/virtual-core': 3.13.12
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-    dev: true
-
-  /@tanstack/react-virtual/3.13.6_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-WT7nWs8ximoQ0CDx/ngoFP7HbQF9Q2wQe4nh2NB+u2486eX3nZRE40P9g6ccCVq7ZfTSH5gFOuCoVH5DLNS/aA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    dependencies:
-      '@tanstack/virtual-core': 3.13.6
-      react: 18.3.1
-      react-dom: 18.3.1_react@18.3.1
-    dev: false
 
   /@tanstack/virtual-core/3.13.12:
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
-    dev: true
-
-  /@tanstack/virtual-core/3.13.6:
-    resolution: {integrity: sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==}
-    dev: false
 
   /@testing-library/dom/10.4.0:
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -6020,19 +5951,6 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@typescript-eslint/utils': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/experimental-utils/5.62.0_eslint@8.57.1:
-    resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0_eslint@8.57.1
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -9950,35 +9868,6 @@ packages:
       get-stdin: 6.0.0
     dev: true
 
-  /eslint-config-react-app/7.0.1_avq3eyf5kaj6ssrwo7fvkrwnji:
-    resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      eslint: ^8.0.0
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/eslint-parser': 7.27.0_rjhet7ys23cyrisbcihkilf5wu
-      '@rushstack/eslint-patch': 1.11.0
-      '@typescript-eslint/eslint-plugin': 5.62.0_xjofbppfavgzddet3eqaopcxxe
-      '@typescript-eslint/parser': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
-      babel-preset-react-app: 10.1.0
-      confusing-browser-globals: 1.0.11
-      eslint: 8.57.1
-      eslint-plugin-flowtype: 8.0.3_eslint@8.57.1
-      eslint-plugin-import: 2.31.0_eslint@8.57.1
-      eslint-plugin-jest: 25.7.0_vmupg6xtr6wf42awf4y46hfrea
-      eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
-      eslint-plugin-react: 7.37.5_eslint@8.57.1
-      eslint-plugin-react-hooks: 4.6.2_eslint@8.57.1
-      eslint-plugin-testing-library: 5.11.1_avq3eyf5kaj6ssrwo7fvkrwnji
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - jest
-      - supports-color
-      - typescript
-    dev: true
-
   /eslint-config-react-app/7.0.1_bw7kk2ci4knuncltf2ikoilu5e:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
@@ -10008,35 +9897,6 @@ packages:
       - typescript
     dev: true
 
-  /eslint-config-react-app/7.0.1_eslint@8.57.1:
-    resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      eslint: ^8.0.0
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/eslint-parser': 7.27.0_rjhet7ys23cyrisbcihkilf5wu
-      '@rushstack/eslint-patch': 1.11.0
-      '@typescript-eslint/eslint-plugin': 5.62.0_pxvohtismendhqqucj752ob6hu
-      '@typescript-eslint/parser': 5.62.0_eslint@8.57.1
-      babel-preset-react-app: 10.1.0
-      confusing-browser-globals: 1.0.11
-      eslint: 8.57.1
-      eslint-plugin-flowtype: 8.0.3_eslint@8.57.1
-      eslint-plugin-import: 2.31.0_eslint@8.57.1
-      eslint-plugin-jest: 25.7.0_szoveuheeurieyvmhs4yzcbatq
-      eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
-      eslint-plugin-react: 7.37.5_eslint@8.57.1
-      eslint-plugin-react-hooks: 4.6.2_eslint@8.57.1
-      eslint-plugin-testing-library: 5.11.1_eslint@8.57.1
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - jest
-      - supports-color
-      - typescript
-    dev: true
-
   /eslint-import-resolver-node/0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
@@ -10056,17 +9916,6 @@ packages:
     dependencies:
       debug: 3.2.7
       eslint: 8.57.1
-    dev: true
-
-  /eslint-plugin-flowtype/5.10.0_eslint@8.57.1:
-    resolution: {integrity: sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^7.1.0
-    dependencies:
-      eslint: 8.57.1
-      lodash: 4.17.21
-      string-natural-compare: 3.0.1
     dev: true
 
   /eslint-plugin-flowtype/8.0.3_eslint@8.57.1:
@@ -10127,48 +9976,6 @@ packages:
       '@typescript-eslint/experimental-utils': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint: 8.57.1
       jest: 27.5.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /eslint-plugin-jest/25.7.0_szoveuheeurieyvmhs4yzcbatq:
-    resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0_pxvohtismendhqqucj752ob6hu
-      '@typescript-eslint/experimental-utils': 5.62.0_eslint@8.57.1
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /eslint-plugin-jest/25.7.0_vmupg6xtr6wf42awf4y46hfrea:
-    resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0_xjofbppfavgzddet3eqaopcxxe
-      '@typescript-eslint/experimental-utils': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
-      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10290,19 +10097,6 @@ packages:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
       '@typescript-eslint/utils': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /eslint-plugin-testing-library/5.11.1_eslint@8.57.1:
-    resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0_eslint@8.57.1
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color

--- a/common/scripts/.eslintrc.ts.base.json
+++ b/common/scripts/.eslintrc.ts.base.json
@@ -2,7 +2,6 @@
   "extends": [
     "plugin:@typescript-eslint/recommended",
     "prettier/@typescript-eslint",
-    "react-app",
     "plugin:react/recommended",
     "plugin:prettier/recommended"
   ],
@@ -18,21 +17,147 @@
       }
     }
   },
-  "plugins": ["simple-import-sort", "@typescript-eslint"],
+  "plugins": [
+    "simple-import-sort",
+    "@typescript-eslint",
+    "react-hooks",
+    "import",
+    "jsx-a11y"
+  ],
   "rules": {
     "no-console": "off",
     "import/prefer-default-export": "off",
     "radix": "off",
     "no-use-before-define": "off",
+    "react/no-unescaped-entities": "off",
+    "react/display-name": "off",
+    "react/prop-types": "off",
+    "no-unused-vars": "off",
+
+    "react-hooks/rules-of-hooks": "error",
+
+    "array-callback-return": "warn",
+    "default-case": ["warn", { "commentPattern": "^no default$" }],
+    "eqeqeq": ["warn", "smart"],
+    "new-parens": "warn",
+    "no-caller": "warn",
+    "no-cond-assign": ["warn", "except-parens"],
+    "no-control-regex": "warn",
+    "no-delete-var": "warn",
+    "no-duplicate-case": "warn",
+    "no-empty-character-class": "warn",
+    "no-empty-pattern": "warn",
+    "no-eval": "warn",
+    "no-ex-assign": "warn",
+    "no-extend-native": "warn",
+    "no-extra-bind": "warn",
+    "no-extra-label": "warn",
+    "no-fallthrough": "warn",
+    "no-global-assign": "warn",
+    "no-implied-eval": "warn",
+    "no-invalid-regexp": "warn",
+    "no-iterator": "warn",
+    "no-label-var": "warn",
+    "no-labels": ["warn", { "allowLoop": true, "allowSwitch": false }],
+    "no-lone-blocks": "warn",
+    "no-loop-func": "warn",
+    "no-multi-str": "warn",
+    "no-new-func": "warn",
+    "no-new-object": "warn",
+    "no-new-wrappers": "warn",
+    "no-octal": "warn",
+    "no-octal-escape": "warn",
+    "no-redeclare": "off",
+    "no-regex-spaces": "warn",
+    "no-restricted-syntax": ["warn", "WithStatement"],
+    "no-script-url": "warn",
+    "no-self-assign": "warn",
+    "no-self-compare": "warn",
+    "no-sequences": "warn",
+    "no-shadow-restricted-names": "warn",
+    "no-sparse-arrays": "warn",
+    "no-template-curly-in-string": "warn",
+    "no-throw-literal": "warn",
+    "no-unsafe-negation": "warn",
+    "no-unused-expressions": "off",
+    "no-unused-labels": "warn",
+    "no-useless-computed-key": "warn",
+    "no-useless-concat": "warn",
+    "no-useless-escape": "warn",
+    "no-useless-rename": [
+      "warn",
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-with": "warn",
+    "require-yield": "warn",
+    "strict": ["warn", "never"],
+    "use-isnan": "warn",
+
+    "import/first": "error",
+    "import/no-amd": "error",
+    "import/no-anonymous-default-export": "warn",
+    "import/no-webpack-loader-syntax": "error",
+
+    "jsx-a11y/alt-text": "warn",
+    "jsx-a11y/anchor-has-content": "warn",
+    "jsx-a11y/anchor-is-valid": [
+      "warn",
+      { "aspects": ["noHref", "invalidHref"] }
+    ],
+    "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
+    "jsx-a11y/aria-props": "warn",
+    "jsx-a11y/aria-proptypes": "warn",
+    "jsx-a11y/aria-role": ["warn", { "ignoreNonDOM": true }],
+    "jsx-a11y/aria-unsupported-elements": "warn",
+    "jsx-a11y/heading-has-content": "warn",
+    "jsx-a11y/iframe-has-title": "warn",
+    "jsx-a11y/img-redundant-alt": "warn",
+    "jsx-a11y/no-access-key": "warn",
+    "jsx-a11y/no-distracting-elements": "warn",
+    "jsx-a11y/no-redundant-roles": "warn",
+    "jsx-a11y/role-has-required-aria-props": "warn",
+    "jsx-a11y/role-supports-aria-props": "warn",
+    "jsx-a11y/scope": "warn",
+
+    "react/forbid-foreign-prop-types": ["warn", { "allowInPropTypes": true }],
+    "react/jsx-pascal-case": ["warn", { "allowAllCaps": true }],
+    "react/no-typos": "error",
+    "react/style-prop-object": "warn",
+
+    "@typescript-eslint/consistent-type-assertions": "warn",
+    "@typescript-eslint/no-array-constructor": "warn",
+    "@typescript-eslint/no-redeclare": "warn",
+    "@typescript-eslint/no-use-before-define": [
+      "warn",
+      {
+        "functions": false,
+        "classes": false,
+        "variables": false,
+        "typedefs": false
+      }
+    ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      1,
+      { "args": "none", "ignoreRestSiblings": true }
+    ],
+    "@typescript-eslint/no-useless-constructor": "warn",
+
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",
-    "react/no-unescaped-entities": "off",
-    "react/display-name": "off",
-    "react/prop-types": "off",
-    "@typescript-eslint/interface-name-prefix": "off",
-    "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": [1, { "ignoreRestSiblings": true }]
+    "@typescript-eslint/interface-name-prefix": "off"
   }
 }

--- a/common/scripts/.eslintrc.ts.base.json
+++ b/common/scripts/.eslintrc.ts.base.json
@@ -29,13 +29,21 @@
     "import/prefer-default-export": "off",
     "radix": "off",
     "no-use-before-define": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/explicit-member-accessibility": "off",
     "react/no-unescaped-entities": "off",
     "react/display-name": "off",
     "react/prop-types": "off",
+    "@typescript-eslint/interface-name-prefix": "off",
     "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      1,
+      { "args": "none", "ignoreRestSiblings": true }
+    ],
 
     "react-hooks/rules-of-hooks": "error",
-
     "array-callback-return": "warn",
     "default-case": ["warn", { "commentPattern": "^no default$" }],
     "eqeqeq": ["warn", "smart"],
@@ -148,16 +156,7 @@
         "allowTaggedTemplates": true
       }
     ],
-    "@typescript-eslint/no-unused-vars": [
-      1,
-      { "args": "none", "ignoreRestSiblings": true }
-    ],
-    "@typescript-eslint/no-useless-constructor": "warn",
 
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/explicit-member-accessibility": "off",
-    "@typescript-eslint/interface-name-prefix": "off"
+    "@typescript-eslint/no-useless-constructor": "warn"
   }
 }

--- a/common/scripts/package.json
+++ b/common/scripts/package.json
@@ -10,8 +10,6 @@
     "babel-eslint": "^10.0.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/apps/storybook/package.json
+++ b/packages/apps/storybook/package.json
@@ -40,8 +40,6 @@
     "babel-loader": "^8.2.5",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/modules/create-imodel/package.json
+++ b/packages/modules/create-imodel/package.json
@@ -45,8 +45,6 @@
     "@typescript-eslint/parser": "^5.62.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/modules/delete-imodel/package.json
+++ b/packages/modules/delete-imodel/package.json
@@ -45,8 +45,6 @@
     "@typescript-eslint/parser": "^5.62.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/modules/delete-itwin/package.json
+++ b/packages/modules/delete-itwin/package.json
@@ -45,8 +45,6 @@
     "@typescript-eslint/parser": "^5.62.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/modules/imodel-browser/package.json
+++ b/packages/modules/imodel-browser/package.json
@@ -53,8 +53,6 @@
     "eslint": "^8.3.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/modules/manage-versions/package.json
+++ b/packages/modules/manage-versions/package.json
@@ -49,8 +49,6 @@
     "@typescript-eslint/parser": "^5.62.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/packages/modules/storybook-auth-addon/package.json
+++ b/packages/modules/storybook-auth-addon/package.json
@@ -21,8 +21,6 @@
     "babel-eslint": "^10.0.0",
     "eslint-config-airbnb": "^0.0.4",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
It is pinned to @typescript-eslint/parser 5.x and blocks us from upgrading Typescript (which I'm hoping to do in #202).

The whole CRA project is deprecated anyways

https://github.com/react/create-react-app/blob/main/packages/eslint-config-react-app/package.json

We also remove eslint-plugin-flowtype since we don't use Flow at all

---

I copied in [the rules from CRA](https://github.com/react/create-react-app/blob/main/packages/eslint-config-react-app/index.js) with a few exceptions...


Already in `plugin:react/recommended`...

react/jsx-no-comment-textnodes, react/jsx-no-duplicate-props, react/jsx-no-target-blank, react/jsx-no-undef, react/no-danger-with-children, react/no-direct-mutation-state, react/no-is-mounted, react/require-render-return

Handled by Typescript...

no-const-assign, no-dupe-args, no-dupe-class-members, no-dupe-keys, no-func-assign, no-new-symbol, no-obj-calls, no-this-before-super, no-undef, no-unreachable, valid-typeof, getter-return

Handled by Prettier...

dot-location, no-mixed-operators, no-whitespace-before-property, rest-spread-spacing, unicode-bom

Specific to create-react-app

no-restricted-properties, no-restricted-globals