### PR TITLE
Fix pre-commit hook finding multiple eslint-plugin-prettier

### DIFF
--- a/common/scripts/pre-commit.js
+++ b/common/scripts/pre-commit.js
@@ -8,9 +8,9 @@ async function preCommit() {
   const success = await lintStaged({
     config: {
       "*.{ts,tsx,js,jsx}": [
-        "node --max_old_space_size=4096 ./common/scripts/node_modules/eslint/bin/eslint.js --config ./common/scripts/.eslintrc.ts.autofix.json --ignore-path ./.eslintignore --fix",
+        "node --max_old_space_size=4096 ./common/scripts/node_modules/eslint/bin/eslint.js --config ./common/scripts/.eslintrc.ts.autofix.json --ignore-path ./.eslintignore --resolve-plugins-relative-to ./common/scripts --fix",
         "node ./common/scripts/node_modules/prettier --write --config ./.prettierrc --ignore-path ./.prettierignore",
-        "node --max_old_space_size=4096 ./common/scripts/node_modules/eslint/bin/eslint.js --config ./common/scripts/.eslintrc.ts.json --ignore-path ./.eslintignore --color",
+        "node --max_old_space_size=4096 ./common/scripts/node_modules/eslint/bin/eslint.js --config ./common/scripts/.eslintrc.ts.json --ignore-path ./.eslintignore --resolve-plugins-relative-to ./common/scripts --color",
         "node ./common/scripts/copyright-linter.js --",
       ],
       "*.{md,json}": [


### PR DESCRIPTION
The pre-commit hook has been broken for me since I started working on this repo.


<img width="1261" height="509" alt="Screenshot 2026-06-04 at 10 58 02 AM" src="https://github.com/user-attachments/assets/0c9d0aed-285a-47a3-877f-e3ae4cdb26b3" />


This PR adds eslint's `resolve-plugins-relative-to` flag as a fix.  Future versions of eslint deprecate this flag, but it works without issue in our current 8.x configuration.  We can re-evaluate in the future when we update eslint.
