### PR TITLE
Fix Stratakit storybook icons when built

### DIFF
--- a/packages/apps/storybook/.storybook/main.js
+++ b/packages/apps/storybook/.storybook/main.js
@@ -51,7 +51,6 @@ module.exports = {
       type: "asset/resource",
       generator: {
         filename: "static/media/[name].[contenthash:8][ext]",
-        publicPath: "/",
       },
     });
 


### PR DESCRIPTION
[Built Storybook](https://itwin.github.io/admin-components-react/) is not rendering Stratakit's SVG icons when deployed to Github pages due to the `/admin-components-react/` path.

This PR removes `publicPath` so Storybook can be built and deployed in any directory.
