### PR TITLE
Wait for table rows in manage-versions test

### DIFF
--- a/common/changes/@itwin/manage-versions-react/alex-fix-flakey-manage-versions-test_2026-06-17-18-09.json
+++ b/common/changes/@itwin/manage-versions-react/alex-fix-flakey-manage-versions-test_2026-06-17-18-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/manage-versions-react",
+      "comment": "Fix flakey table row test",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/manage-versions-react"
+}

--- a/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
+++ b/packages/modules/manage-versions/src/components/ManageVersions/ManageVersions.test.tsx
@@ -119,11 +119,16 @@ describe("ManageVersions", () => {
       expect(container.querySelector(".iac-changes-table-body")).toBeVisible()
     );
 
+    await waitFor(() => {
+      const rows = container.querySelectorAll(
+        ".iac-changes-table-body [role='row']"
+      );
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+    });
+
     const changesetRows = container.querySelectorAll(
       ".iac-changes-table-body [role='row']"
     );
-    // Virtualization renders only visible rows
-    expect(changesetRows.length).toBeGreaterThanOrEqual(1);
 
     changesetRows.forEach((row, index) => {
       const cells = row.querySelectorAll("div[role='cell']");


### PR DESCRIPTION
This test was flaky previously.

Confirmed by running CI 3x without any failures.