### PR TITLE
Increase default page size for Stratakit components

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/alex-stratakit-fetch-enhancements_2026-06-17-21-46.json
+++ b/common/changes/@itwin/imodel-browser-react/alex-stratakit-fetch-enhancements_2026-06-17-21-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Increase default page size for Stratakit components",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
@@ -24,9 +24,10 @@ export interface ProjectDataHookOptions {
   orderbyOptions?: string;
   shouldRefetchFavorites?: boolean;
   resetShouldRefetchFavorites?: () => void;
+  pageSize?: number;
 }
 
-const PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 100;
 
 export const useITwinData = ({
   requestType = "",
@@ -37,6 +38,7 @@ export const useITwinData = ({
   orderbyOptions,
   shouldRefetchFavorites,
   resetShouldRefetchFavorites,
+  pageSize = DEFAULT_PAGE_SIZE,
 }: ProjectDataHookOptions) => {
   const data = apiOverrides?.data;
   const serverEnvironmentPrefix = apiOverrides?.serverEnvironmentPrefix;
@@ -115,7 +117,7 @@ export const useITwinData = ({
       : "";
     const resolvedITwinSubClass = iTwinSubClass === "All" ? "" : iTwinSubClass;
     const subClass = `?subClass=${resolvedITwinSubClass}`;
-    const paging = `&$skip=${page * PAGE_SIZE}&$top=${PAGE_SIZE}`;
+    const paging = `&$skip=${page * pageSize}&$top=${pageSize}`;
     const search =
       ["favorites", "recents"].includes(requestType) || !filterOptions
         ? ""
@@ -155,7 +157,7 @@ export const useITwinData = ({
       setStatus(DataStatus.Complete);
       fetchingMoreRef.current = false;
       requestType === "favorites" && resetShouldRefetchFavorites?.();
-      if (result.iTwins.length !== PAGE_SIZE) {
+      if (result.iTwins.length !== pageSize) {
         setMorePages(false);
       }
       setProjects((projects) =>
@@ -188,6 +190,7 @@ export const useITwinData = ({
     iTwinSubClass,
     shouldRefetchFavorites,
     resetShouldRefetchFavorites,
+    pageSize,
   ]);
   return {
     iTwins: filteredProjects,

--- a/packages/modules/imodel-browser/src/mui/containers/ITwinGrid/ITwinGridMUI.tsx
+++ b/packages/modules/imodel-browser/src/mui/containers/ITwinGrid/ITwinGridMUI.tsx
@@ -26,6 +26,8 @@ import { stripNonTileProps } from "../../utils/stripNonTileProps";
 import { type ITwinTableMUIStrings, ITwinTableMUI } from "./ITwinTableMUI";
 import { type ITwinTilePropsMUI, ITwinTileMUI } from "./ITwinTileMUI";
 
+const DEFAULT_PAGE_SIZE = 250;
+
 /** @alpha */
 export type IndividualITwinStateHookMUI = (
   iTwin: ITwinFull,
@@ -161,6 +163,7 @@ export const ITwinGridMUI = ({
     orderbyOptions,
     shouldRefetchFavorites,
     resetShouldRefetchFavorites,
+    pageSize: DEFAULT_PAGE_SIZE,
   });
 
   const iTwins = React.useMemo(

--- a/packages/modules/imodel-browser/src/mui/containers/iModelGrid/IModelGridMUI.tsx
+++ b/packages/modules/imodel-browser/src/mui/containers/iModelGrid/IModelGridMUI.tsx
@@ -7,10 +7,7 @@ import React from "react";
 import { InView } from "react-intersection-observer";
 
 import type { IModelGridProps } from "../../../containers/iModelGrid/IModelGrid";
-import {
-  DEFAULT_PAGE_SIZE,
-  useIModelData,
-} from "../../../containers/iModelGrid/useIModelData";
+import { useIModelData } from "../../../containers/iModelGrid/useIModelData";
 import { IModelFavoritesProvider } from "../../../contexts/IModelFavoritesContext";
 import {
   type AccessTokenProvider,
@@ -39,6 +36,8 @@ import {
 } from "../iModelTiles/IModelTileMUI";
 import { clientSideIModelSort } from "./clientSideIModelSort";
 import { type IModelTableMUIStrings, IModelTableMUI } from "./IModelTableMUI";
+
+const DEFAULT_PAGE_SIZE = 250;
 
 /**
  * Localized strings for the MUI IModelGrid. Extends the table-level strings
@@ -243,7 +242,7 @@ const IModelGridInternal = ({
     sortOptions: sort,
     searchText,
     maxCount,
-    pageSize,
+    pageSize: DEFAULT_PAGE_SIZE,
     viewMode,
     dataMode,
     onLoadMore,


### PR DESCRIPTION
Stratakit uses MUI Datagrid which doesn't support loading "more records" when scrolling to the end of a data table.  

This is an interim work-around to fetch more records (100 -> 250) to give us a higher likelihood of getting all of a user's iTwin / iModel data without introducing logic updates to the data-fetching hooks used by non-Stratakit components