### PR TITLE
feat(storybook): add iTwinId argType to IModelGrid and IModelGridMUI

### DIFF
--- a/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/IModelGrid.stories.tsx
@@ -42,6 +42,9 @@ export default {
   component: IModelGrid,
   argTypes: {
     ...accessTokenArgTypes,
+    iTwinId: {
+      control: { type: "text" },
+    },
     requestType: {
       options: ["all", "recents", "favorites"],
       mapping: {
@@ -285,27 +288,28 @@ const buildMenuItems =
     close: () => void,
     setVersion: React.Dispatch<React.SetStateAction<Version | undefined>>
   ) =>
-  (v: Version) => (
-    <span
-      onClick={(event) => {
-        event.stopPropagation();
-      }}
-    >
-      {v.id === "loading" ? (
-        <MenuItemSkeleton />
-      ) : (
-        <MenuItem
-          key={v.id}
-          onClick={() => {
-            close();
-            v.id !== "loading" && setVersion(v);
-          }}
-        >
-          {v.displayName}
-        </MenuItem>
-      )}
-    </span>
-  );
+  (v: Version) =>
+    (
+      <span
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        {v.id === "loading" ? (
+          <MenuItemSkeleton />
+        ) : (
+          <MenuItem
+            key={v.id}
+            onClick={() => {
+              close();
+              v.id !== "loading" && setVersion(v);
+            }}
+          >
+            {v.displayName}
+          </MenuItem>
+        )}
+      </span>
+    );
 
 /** Hook used in StatefulPropsOverrides.args, the function itself must be a stable reference as it is a hook. */
 const useIndividualState = (iModel: IModelFull, props: IModelTileProps) => {

--- a/packages/apps/storybook/src/imodel-browser/mui/IModelGridMUI.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/mui/IModelGridMUI.stories.tsx
@@ -40,6 +40,13 @@ export default {
   component: IModelGridMUI,
   argTypes: {
     ...accessTokenArgTypes,
+    // Explicitly declared so the project-selection toolbar (which keys off
+    // `useArgTypes().iTwinId`) renders. react-docgen-typescript does not expand
+    // the `Omit<IModelGridProps, ...>` used by IModelGridMUIProps, so this
+    // argType would otherwise be missing.
+    iTwinId: {
+      control: { type: "text" },
+    },
     requestType: {
       options: ["all", "recents", "favorites"],
       mapping: {

--- a/packages/apps/storybook/tsconfig.json
+++ b/packages/apps/storybook/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": true,
     "strictNullChecks": true,
     "paths": {
       "@itwin/imodel-browser-react/mui": [


### PR DESCRIPTION
Fix IModelGrid and IModelGridMUI stories showing 
<img width="456" height="250" alt="image" src="https://github.com/user-attachments/assets/255f1adb-7653-4416-bb2e-eff5264c2eff" />
