### PR TITLE
Add totalCount as an argument to postProcessCallback

### DIFF
--- a/common/changes/@itwin/imodel-browser-react/DanishM-iTwinCount_2026-08-04-05-51.json
+++ b/common/changes/@itwin/imodel-browser-react/DanishM-iTwinCount_2026-08-04-05-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-browser-react",
+      "comment": "Add totalCount as an argument to `postProcessCallback`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/imodel-browser-react"
+}

--- a/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
+++ b/packages/apps/storybook/src/imodel-browser/ITwinGrid.stories.tsx
@@ -316,8 +316,14 @@ export const StatefulPropsOverrides: StoryObj<typeof ITwinGrid> = {
 };
 
 const WithPostProcessCallbackRender = (args: ITwinGridProps) => {
+  const [totalCount, setTotalCount] = React.useState<number | undefined>();
   const addStartTile = React.useCallback(
-    (iTwins: ITwinFull[], status: DataStatus | undefined) => {
+    (
+      iTwins: ITwinFull[],
+      status: DataStatus | undefined,
+      totalCount: number | undefined
+    ) => {
+      setTotalCount(totalCount);
       if (status !== DataStatus.Complete) {
         return iTwins;
       }
@@ -336,7 +342,11 @@ const WithPostProcessCallbackRender = (args: ITwinGridProps) => {
       <Text as="p" variant="body">
         Property <Code>postProcessCallback</Code> allows modification of the
         data that is sent to the grid, here, we add a new tile at the start of
-        the list for a 'New Project'.
+        the list for a 'New Project'. It also receives the{" "}
+        <Code>totalCount</Code> from the response headers.
+      </Text>
+      <Text as="p" variant="body">
+        Total iTwin count: {totalCount ?? "unknown"}
       </Text>
       <ITwinGrid {...args} postProcessCallback={addStartTile} />
     </div>

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/ITwinGrid.tsx
@@ -103,7 +103,8 @@ export interface ITwinGridProps {
    */
   postProcessCallback?: (
     iTwins: ITwinFull[],
-    fetchStatus: DataStatus | undefined
+    fetchStatus: DataStatus | undefined,
+    totalCount: number | undefined
   ) => ITwinFull[];
   /**iTwin view mode */
   viewMode?: ViewType;
@@ -178,6 +179,7 @@ const ITwinGridInternal = ({
   const {
     iTwins: fetchedItwins,
     status: fetchStatus,
+    totalCount,
     fetchMore,
     refetchITwins,
   } = useITwinData({
@@ -193,8 +195,9 @@ const ITwinGridInternal = ({
 
   const iTwins = React.useMemo(
     () =>
-      postProcessCallback?.([...fetchedItwins], fetchStatus) ?? fetchedItwins,
-    [postProcessCallback, fetchedItwins, fetchStatus]
+      postProcessCallback?.([...fetchedItwins], fetchStatus, totalCount) ??
+      fetchedItwins,
+    [postProcessCallback, fetchedItwins, fetchStatus, totalCount]
   );
 
   const { columns, onRowClick } = useITwinTableConfig({

--- a/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
+++ b/packages/modules/imodel-browser/src/containers/ITwinGrid/useITwinData.ts
@@ -44,6 +44,7 @@ export const useITwinData = ({
   const serverEnvironmentPrefix = apiOverrides?.serverEnvironmentPrefix;
   const [projects, setProjects] = React.useState<ITwinFull[]>([]);
   const [status, setStatus] = React.useState<DataStatus>();
+  const [totalCount, setTotalCount] = React.useState<number>();
   const filteredProjects = useITwinFilter(projects, filterOptions);
   const [page, setPage] = React.useState(0);
   const [morePages, setMorePages] = React.useState(true);
@@ -146,6 +147,7 @@ export const useITwinData = ({
               : accessToken,
           Accept: "application/vnd.bentley.itwin-platform.v1+json",
           Prefer: "return=representation",
+          "x-total-count": "true",
         },
       };
 
@@ -155,6 +157,10 @@ export const useITwinData = ({
         : await response.text().then((errorText) => {
             throw new Error(errorText);
           });
+      const totalCountHeader = response.headers.get("x-total-count");
+      if (totalCountHeader !== null) {
+        setTotalCount(Number(totalCountHeader));
+      }
       setStatus(DataStatus.Complete);
       fetchingMoreRef.current = false;
       requestType === "favorites" && resetShouldRefetchFavorites?.();
@@ -196,6 +202,7 @@ export const useITwinData = ({
   return {
     iTwins: filteredProjects,
     status,
+    totalCount,
     fetchMore: morePages ? fetchMore : undefined,
     refetchITwins: refetchData,
   };

--- a/packages/modules/imodel-browser/src/mui/containers/ITwinGrid/ITwinGridMUI.tsx
+++ b/packages/modules/imodel-browser/src/mui/containers/ITwinGrid/ITwinGridMUI.tsx
@@ -165,6 +165,7 @@ const ITwinGridMUIInternal = ({
   const {
     iTwins: fetchedItwins,
     status: fetchStatus,
+    totalCount,
     fetchMore,
     refetchITwins,
   } = useITwinData({
@@ -180,8 +181,9 @@ const ITwinGridMUIInternal = ({
 
   const iTwins = React.useMemo(
     () =>
-      postProcessCallback?.([...fetchedItwins], fetchStatus) ?? fetchedItwins,
-    [postProcessCallback, fetchedItwins, fetchStatus]
+      postProcessCallback?.([...fetchedItwins], fetchStatus, totalCount) ??
+      fetchedItwins,
+    [postProcessCallback, fetchedItwins, fetchStatus, totalCount]
   );
 
   const noResultsText = {


### PR DESCRIPTION
Providing the option to get totalCount of selected type of iTwins from `postProcessCallback`. Useful for tracking analytics events.